### PR TITLE
upgraded  cached_network_image version to 1.0.0 . was causing depende…

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
 
 dependencies:
-  cached_network_image: ^0.8.0
+  cached_network_image: ^1.0.0
   flutter:
     sdk: flutter
   flutter_widget_from_html_core:


### PR DESCRIPTION
Hey . i just changed the dependency of the cached network image to 1.0.0 because i was getting this error : 
Because no versions of flutter_widget_from_html match >0.2.1+1 <0.3.0 and flutter_widget_from_html 0.2.1+1 depends on cached_network_image ^0.8.0, flutter_widget_from_html ^0.2.1+1 requires cached_network_image ^0.8.0.
And because no versions of cached_network_image match >0.8.0 <0.9.0 and cached_network_image 0.8.0 depends on flutter_cache_manager ^0.3.2, flutter_widget_from_html ^0.2.1+1 requires flutter_cache_manager ^0.3.2.
Because flutter_cache_manager 0.3.2 depends on path_provider ^0.5.0+1 and no versions of flutter_cache_manager match >0.3.2 <0.4.0, flutter_cache_manager ^0.3.2 requires path_provider ^0.5.0+1.
Thus, flutter_widget_from_html ^0.2.1+1 requires path_provider ^0.5.0+1.
So, because peqas_app depends on both flutter_widget_from_html ^0.2.1+1 and path_provider ^1.1.0, version solving failed.



Please merge asap <3 <3 <3 <3 