### PR TITLE
Fix extra space after BR tag

### DIFF
--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -771,7 +771,7 @@ class WidgetFactory {
 
   BuildOp tagBr() {
     _tagBr ??= BuildOp(
-      onPieces: (_, pieces) => pieces..last.block.addText('\n'),
+      onPieces: (_, pieces) => pieces..last.block.addSpace('\n'),
     );
     return _tagBr;
   }

--- a/packages/core/lib/src/data_classes.dart
+++ b/packages/core/lib/src/data_classes.dart
@@ -343,10 +343,11 @@ class DataBit extends TextBit {
 
 class SpaceBit extends TextBit {
   final TextBlock block;
+  final String data;
 
-  SpaceBit(this.block) : assert(block != null);
+  SpaceBit(this.block, {this.data}) : assert(block != null);
 
-  bool get hasTrailingSpace => true;
+  bool get hasTrailingSpace => data == null;
 }
 
 class WidgetBit extends TextBit {
@@ -442,9 +443,9 @@ class TextBlock extends TextBit {
   void addBit(TextBit bit, {int index}) =>
       _children.insert(index ?? _children.length, bit);
 
-  bool addSpace() {
-    if (hasTrailingSpace) return false;
-    addBit(SpaceBit(this));
+  bool addSpace([String data]) {
+    if (data == null && (last is SpaceBit || hasTrailingSpace)) return false;
+    addBit(SpaceBit(this, data: data));
     return true;
   }
 

--- a/packages/core/lib/src/data_classes.dart
+++ b/packages/core/lib/src/data_classes.dart
@@ -304,102 +304,87 @@ class NodeMetadata {
 
 typedef NodeMetadata NodeMetadataCollector(NodeMetadata meta, dom.Element e);
 
-abstract class _TextBit {
-  TextBit get first;
-  bool get hasTrailingSpace;
-  bool get isEmpty;
-  TextBit get last;
+abstract class TextBit {
+  TextBlock get block;
 
+  String get data => null;
+  TextBit get first => this;
+  bool get hasTrailingSpace => false;
+  bool get isEmpty => false;
   bool get isNotEmpty => !isEmpty;
+  TextBit get last => this;
+  VoidCallback get onTap => null;
+  TextStyleBuilders get tsb => null;
 }
 
-class TextBit extends _TextBit {
+class DataBit extends TextBit {
   final TextBlock block;
   final String data;
   final VoidCallback onTap;
   final TextStyleBuilders tsb;
-  final WidgetSpan widgetSpan;
 
-  TextBit.text(this.block, this.data, this.tsb, {this.onTap})
+  DataBit(this.block, this.data, this.tsb, {this.onTap})
       : assert(block != null),
         assert(data != null),
-        assert(tsb != null),
-        widgetSpan = null;
+        assert(tsb != null);
 
-  TextBit.space(this.block)
-      : assert(block != null),
-        data = null,
-        onTap = null,
-        tsb = null,
-        widgetSpan = null;
-
-  TextBit.widget(this.block, this.widgetSpan)
-      : assert(block != null),
-        assert(widgetSpan != null),
-        data = null,
-        onTap = null,
-        tsb = null;
-
-  @override
-  TextBit get first => this;
-
-  @override
-  bool get hasTrailingSpace => isSpace;
-
-  @override
-  bool get isEmpty => false;
-
-  @override
-  TextBit get last => this;
-
-  bool get isSpace => data == null && widgetSpan == null;
-  bool get isText => data != null;
-  bool get isWidget => widgetSpan != null;
-
-  TextBit rebuild({
+  DataBit rebuild({
     String data,
     VoidCallback onTap,
     TextStyleBuilders tsb,
-    WidgetSpan widgetSpan,
   }) =>
-      isText
-          ? TextBit.text(
-              block,
-              data ?? this.data,
-              tsb ?? this.tsb,
-              onTap: onTap ?? this.onTap,
-            )
-          : isWidget
-              ? TextBit.widget(block, widgetSpan ?? this.widgetSpan)
-              : this;
+      DataBit(
+        block,
+        data ?? this.data,
+        tsb ?? this.tsb,
+        onTap: onTap ?? this.onTap,
+      );
+}
 
-  TextBit rebuildWidget({
+class SpaceBit extends TextBit {
+  final TextBlock block;
+
+  SpaceBit(this.block) : assert(block != null);
+
+  bool get hasTrailingSpace => true;
+}
+
+class WidgetBit extends TextBit {
+  final TextBlock block;
+  final WidgetSpan widgetSpan;
+
+  WidgetBit(this.block, this.widgetSpan)
+      : assert(block != null),
+        assert(widgetSpan != null);
+
+  WidgetBit rebuild({
     PlaceholderAlignment alignment,
     TextBaseline baseline,
     Widget child,
   }) =>
-      isWidget
-          ? rebuild(
-              widgetSpan: WidgetSpan(
-                alignment: alignment ?? this.widgetSpan.alignment,
-                baseline: baseline ?? this.widgetSpan.baseline,
-                child: child ?? this.widgetSpan.child,
-              ),
-            )
-          : this;
+      WidgetBit(
+        block,
+        WidgetSpan(
+          alignment: alignment ?? this.widgetSpan.alignment,
+          baseline: baseline ?? this.widgetSpan.baseline,
+          child: child ?? this.widgetSpan.child,
+        ),
+      );
 }
 
-class TextBlock extends _TextBit {
+class TextBlock extends TextBit {
   final TextBlock parent;
   final TextStyleBuilders tsb;
-  final List<_TextBit> _children = [];
+  final _children = <TextBit>[];
 
   TextBlock(this.tsb, {this.parent}) : assert(tsb != null);
 
   @override
+  TextBlock get block => parent;
+
+  @override
   TextBit get first {
     for (final child in _children) {
-      if (child is TextBit) return child;
       final first = child.first;
       if (first != null) return first;
     }
@@ -433,9 +418,7 @@ class TextBlock extends _TextBit {
   TextBit get last {
     final l = _children.length;
     for (var i = l - 1; i >= 0; i--) {
-      final child = _children[i];
-      if (child is TextBit) return child;
-      final last = child.last;
+      final last = _children[i].last;
       if (last != null) return last;
     }
 
@@ -461,13 +444,13 @@ class TextBlock extends _TextBit {
 
   bool addSpace() {
     if (hasTrailingSpace) return false;
-    addBit(TextBit.space(this));
+    addBit(SpaceBit(this));
     return true;
   }
 
-  void addText(String data) => addBit(TextBit.text(this, data, tsb));
+  void addText(String data) => addBit(DataBit(this, data, tsb));
 
-  void addWidget(WidgetSpan ws) => addBit(TextBit.widget(this, ws));
+  void addWidget(WidgetSpan ws) => addBit(WidgetBit(this, ws));
 
   bool forEachBit(f(TextBit bit, int index), {bool reversed = false}) {
     final l = _children.length;
@@ -477,9 +460,9 @@ class TextBlock extends _TextBit {
 
     for (var i = i0; i != i1; i += ii) {
       final child = _children[i];
-      final shouldContinue = child is TextBit
-          ? f(child, i)
-          : child is TextBlock ? child.forEachBit(f, reversed: reversed) : null;
+      final shouldContinue = child is TextBlock
+          ? child.forEachBit(f, reversed: reversed)
+          : f(child, i);
       if (shouldContinue == false) return false;
     }
 
@@ -491,10 +474,10 @@ class TextBlock extends _TextBit {
     var l = _children.length;
     while (i < l) {
       final child = _children[i];
-      if (child is TextBit) {
-        _children[i] = f(child);
-      } else if (child is TextBlock) {
+      if (child is TextBlock) {
         child.rebuildBits(f);
+      } else {
+        _children[i] = f(child);
       }
       i++;
     }
@@ -509,14 +492,14 @@ class TextBlock extends _TextBit {
   void trimRight() {
     while (isNotEmpty && hasTrailingSpace) {
       final lastChild = _children.last;
-      if (lastChild is TextBit) {
-        assert(lastChild.isSpace);
-        _children.removeLast();
-      } else if (lastChild is TextBlock) {
+      if (lastChild is TextBlock) {
         lastChild.trimRight();
         if (lastChild.isEmpty) {
           _children.removeLast();
         }
+      } else {
+        assert(lastChild.hasTrailingSpace);
+        _children.removeLast();
       }
     }
   }

--- a/packages/core/lib/src/ops/style_bg_color.dart
+++ b/packages/core/lib/src/ops/style_bg_color.dart
@@ -33,7 +33,7 @@ class _StyleBgColor {
       });
 
   BuiltPiece _buildBlock(BuiltPiece piece, Color bgColor) => piece
-    ..block.rebuildBits((bit) => bit.tsb != null
+    ..block.rebuildBits((bit) => bit is DataBit
         ? bit.rebuild(
             tsb: bit.tsb.sub()..enqueue(_styleBgColorTextStyleBuilder, bgColor),
           )

--- a/packages/core/lib/src/ops/tag_a.dart
+++ b/packages/core/lib/src/ops/tag_a.dart
@@ -33,14 +33,14 @@ class _TagA {
       );
 
   BuiltPiece _buildBlock(BuiltPiece piece, GestureTapCallback onTap) => piece
-    ..block.rebuildBits((b) => b.isWidget
-        ? b.rebuildWidget(
+    ..block.rebuildBits((b) => b is WidgetBit
+        ? b.rebuild(
             child: GestureDetector(
               child: b.widgetSpan.child,
               onTap: onTap,
             ),
           )
-        : b.rebuild(onTap: onTap));
+        : b is DataBit ? b.rebuild(onTap: onTap) : b);
 
   GestureTapCallback _buildGestureTapCallback(NodeMetadata meta) {
     final attrs = meta.domElement.attributes;

--- a/packages/core/lib/src/ops/tag_q.dart
+++ b/packages/core/lib/src/ops/tag_q.dart
@@ -22,9 +22,9 @@ class _TagQ {
           first.forEachBit((bit, i) {
             firstBit ??= bit;
 
-            if (!bit.isSpace) {
+            if (!bit.hasTrailingSpace) {
               final bb = bit.block;
-              bb.addBit(TextBit.text(bb, kTagQOpening, bb.tsb), index: i);
+              bb.addBit(DataBit(bb, kTagQOpening, bb.tsb), index: i);
               addedOpening = true;
               return false;
             }
@@ -37,9 +37,9 @@ class _TagQ {
           last.forEachBit((bit, i) {
             lastBit ??= bit;
 
-            if (!bit.isSpace) {
+            if (!bit.hasTrailingSpace) {
               final bb = bit.block;
-              bb.addBit(TextBit.text(bb, kTagQClosing, bb.tsb), index: i + 1);
+              bb.addBit(DataBit(bb, kTagQClosing, bb.tsb), index: i + 1);
               addedClosing = true;
               return false;
             }
@@ -48,16 +48,13 @@ class _TagQ {
           }, reversed: true);
 
           if (!addedOpening) {
-            first.addBit(
-              TextBit.text(first, kTagQOpening, first.tsb),
-              index: 0,
-            );
-            if (firstBit?.isSpace == true)
-              first.addBit(TextBit.space(first), index: 0);
+            first.addBit(DataBit(first, kTagQOpening, first.tsb), index: 0);
+            if (firstBit?.hasTrailingSpace == true)
+              first.addBit(SpaceBit(first), index: 0);
           }
           if (!addedClosing) {
             last.addText(kTagQClosing);
-            if (lastBit?.isSpace == true) last.addBit(TextBit.space(last));
+            if (lastBit?.hasTrailingSpace == true) last.addBit(SpaceBit(last));
           }
 
           return pieces;

--- a/packages/core/lib/src/ops/text.dart
+++ b/packages/core/lib/src/ops/text.dart
@@ -29,7 +29,7 @@ InlineSpan _compileToTextSpan(BuildContext context, TextBlock b) {
       addChild();
     }
 
-    if (bit.isWidget) {
+    if (bit is WidgetBit) {
       addChild();
       children.add(bit.widgetSpan);
       return;

--- a/packages/core/test/core_test.dart
+++ b/packages/core/test/core_test.dart
@@ -76,10 +76,24 @@ void main() {
             '[RichText:(+i:ADDRESS)]]'));
   });
 
-  testWidgets('renders BR tag', (WidgetTester tester) async {
-    final html = 'Foo<br />Bar';
-    final explained = await explain(tester, html);
-    expect(explained, equals('[RichText:(:Foo\nBar)]'));
+  group('BR', () {
+    testWidgets('renders new line', (WidgetTester tester) async {
+      final html = 'Foo<br />Bar';
+      final explained = await explain(tester, html);
+      expect(explained, equals('[RichText:(:Foo\nBar)]'));
+    });
+
+    testWidgets('renders without whitespace on new line', (tester) async {
+      final html = 'Foo<br />\nBar';
+      final explained = await explain(tester, html);
+      expect(explained, equals('[RichText:(:Foo\nBar)]'));
+    });
+
+    testWidgets('renders multiple new lines', (WidgetTester tester) async {
+      final html = 'Foo<br /><br /><br />';
+      final explained = await explain(tester, html);
+      expect(explained, equals('[RichText:(:Foo\n\n\n)]'));
+    });
   });
 
   testWidgets('renders DD/DL/DT tags', (WidgetTester tester) async {


### PR DESCRIPTION
Sample html:

```html
Foo<br />
Bar
```

It will be rendered like `Foo\n(space)Bar` -> which is wrong. 