### PR TITLE
Upgrade `flutter_svg` to `0.18.0` to support dev+ channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.4.2
-* upgrade svg to latest version to support beta+ channels as well as stable channel
+* [PR #207](https://github.com/daohoangson/flutter_widget_from_html/pull/207) upgrade svg to the latest version to support beta+ channels as well as stable channel [@Saifallak](https://github.com/Saifallak)
 
 ## 0.4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.2
+* upgrade svg to latest version to support beta+ channels as well as stable channel
+
 ## 0.4.1
 
 * BREAKING: Remove `TextStyleBuilders.recognizer` (#168)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for widget tree building from html that supports hyp
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 
 environment:
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.18.0-6.0.pre <2.0.0"
   sdk: ">=2.3.0 <3.0.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_widget_from_html
-version: 0.4.1
+version: 0.4.2
 description: Flutter plugin for widget tree building from html that supports hyperlink, image, nested list, etc.
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 
@@ -12,7 +12,7 @@ dependencies:
   chewie: ^0.9.10
   flutter:
     sdk: flutter
-  flutter_svg: ^0.17.4
+  flutter_svg: ^0.18.0
   flutter_widget_from_html_core: ^0.4.1
   html: ^0.14.0+3
   url_launcher: ^5.4.10


### PR DESCRIPTION
Upgrade [flutter_svg](https://github.com/dnfield/flutter_svg) to `0.18.0` to support dev+ channels.
Also set constraints for using the package to `">=1.18.0-6.0.pre <2.0.0"`.
this can be released as Alpha/Dev on [pub.dev](http://pub.dev) site if wanted.
or we wait until  https://github.com/flutter/flutter/pull/58635 be available on beta channel. and publish this on [pub.dev](http://pub.dev)