### PR TITLE
Use Stack.clipBehavior instead of .overflow

### DIFF
--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -137,7 +137,7 @@ class WidgetFactory {
           BuildMetadata meta, TextStyleHtml tsh, List<Widget> children) =>
       Stack(
         children: children,
-        overflow: Overflow.visible,
+        clipBehavior: Clip.none,
         textDirection: tsh.textDirection,
       );
 

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -6,7 +6,7 @@ homepage: https://github.com/daohoangson/flutter_widget_from_html/tree/master/pa
 environment:
   # Stack.clipBehavior https://github.com/flutter/flutter/commit/42e02d60d3104e97161ba597103854557b2d72ee
   flutter: ">=1.20.0 <2.0.0"
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   flutter:

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -4,7 +4,8 @@ description: Flutter package for widget tree building from html that focuses on 
 homepage: https://github.com/daohoangson/flutter_widget_from_html/tree/master/packages/core
 
 environment:
-  flutter: ">=1.6.7 <2.0.0"
+  # https://github.com/flutter/flutter/commit/7948a7863bd8931e4e029c5b109f26c1b3dcf8ea
+  flutter: ">=1.23.0-4.0.pre <2.0.0"
   sdk: ">=2.3.0 <3.0.0"
 
 dependencies:

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -4,8 +4,8 @@ description: Flutter package for widget tree building from html that focuses on 
 homepage: https://github.com/daohoangson/flutter_widget_from_html/tree/master/packages/core
 
 environment:
-  # https://github.com/flutter/flutter/commit/7948a7863bd8931e4e029c5b109f26c1b3dcf8ea
-  flutter: ">=1.23.0-4.0.pre <2.0.0"
+  # Stack.clipBehavior https://github.com/flutter/flutter/commit/42e02d60d3104e97161ba597103854557b2d72ee
+  flutter: ">=1.20.0 <2.0.0"
   sdk: ">=2.3.0 <3.0.0"
 
 dependencies:

--- a/packages/core/test/_.dart
+++ b/packages/core/test/_.dart
@@ -111,6 +111,7 @@ Future<String> explainWithoutPumping({
     // trim boring properties
     str =
         str.replaceAll(RegExp(r'(, )?(this.)?excludeFromSemantics: false'), '');
+    str = str.replaceAll(RegExp(r'(, )?clipBehavior: none'), '');
     str = str.replaceAll(RegExp(r'(, )?crossAxisAlignment: start'), '');
     str = str.replaceAll(RegExp(r'(, )?direction: vertical'), '');
     str = str.replaceAll(RegExp(r'(, )?filterQuality: low'), '');

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -4,10 +4,9 @@ description: Flutter package for widget tree building from html that supports hy
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 
 environment:
-  # flutter_layout_grid
-  flutter: ">=1.14.0 <2.0.0"
-  # flutter_layout_grid
-  sdk: ">=2.6.0 <3.0.0"
+  # flutter_widget_from_html_core
+  flutter: ">=1.20.0 <2.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   cached_network_image: ^2.2.0+1


### PR DESCRIPTION
Related to #319.

References:

- [This doc describes Flutter’s updated and unified clip strategy for widgets...](https://docs.google.com/document/d/1gC5Di4ykTCqupD77PWpy9D8xXo0Ide5CnrH0zzVIhKo/edit)
- [PR that caused conflict](https://github.com/flutter/flutter/pull/61366)
- [Add Overflow back with deprecation](https://github.com/flutter/flutter/pull/66305)