### PR TITLE
Relax video_player dependency to allow 0.11

### DIFF
--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter_widget_from_html_core: ^0.5.0+5
   html: ^0.14.0+3
   url_launcher: ^5.5.0
-  video_player: ">=0.10.12 <0.12.0"
+  video_player: ">=0.10.12 <1.0.0"
   webview_flutter: ^0.3.22+1
 
 dependency_overrides:

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   flutter_widget_from_html_core: ^0.5.0+5
   html: ^0.14.0+3
   url_launcher: ^5.5.0
-  video_player: ^0.10.12
+  video_player: ">=0.10.12 <0.12.0"
   webview_flutter: ^0.3.22+1
 
 dependency_overrides:


### PR DESCRIPTION
Hi! 

I just bumped at a dependency error while upgrading video_player, now `0.11.0` so I thought I let you know. The minor breaking change does not seem to affect this package. 

Please let me know if this is an acceptable PR or do you require any more changes. 

EDIT: 

Now `chewie` is the problem, they forbid video_player 0.11.

`flutter pub get` outputs

```
Because chewie 0.9.10 depends on video_player >=0.7.0 <0.11.0 and no versions of chewie match >0.9.10 <0.10.0, chewie ^0.9.10 requires video_player >=0.7.0 <0.11.0.

And because every version of flutter_widget_from_html from git depends on chewie ^0.9.10, every version of flutter_widget_from_html from git requires video_player >=0.7.0 <0.11.0.
```

Any workaround? 