### PR TITLE
Use a separated `BuildOp` for `display: block`

### DIFF
--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -11,6 +11,7 @@ import 'core_html_widget.dart';
 /// A factory to build widgets.
 class WidgetFactory {
   BuildOp _styleBgColor;
+  BuildOp _styleBlock;
   BuildOp _styleDisplayNone;
   BuildOp _styleMargin;
   BuildOp _stylePadding;
@@ -721,8 +722,8 @@ class WidgetFactory {
   void parseStyleDisplay(BuildMetadata meta, String value) {
     switch (value) {
       case kCssDisplayBlock:
-        _styleSizing ??= StyleSizing(this).buildOp;
-        meta.register(_styleSizing);
+        _styleBlock ??= DisplayBlockOp(this);
+        meta.register(_styleBlock);
         break;
       case kCssDisplayNone:
         _styleDisplayNone ??= BuildOp(

--- a/packages/core/lib/src/widgets/css_sizing.dart
+++ b/packages/core/lib/src/widgets/css_sizing.dart
@@ -4,10 +4,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 /// A CSS block.
-class CssBlock extends SingleChildRenderObjectWidget {
-  /// The default constraint for block element.
-  static const kBlockWidth = _CssSizingPercentage(100);
-
+class CssBlock extends CssSizing {
   /// Creates a CSS block.
   CssBlock({@required Widget child, Key key})
       : assert(child != null),
@@ -15,7 +12,7 @@ class CssBlock extends SingleChildRenderObjectWidget {
 
   @override
   _RenderCssSizing createRenderObject(BuildContext _) =>
-      _RenderCssSizing(preferredWidth: kBlockWidth);
+      _RenderCssSizing(preferredWidth: const _CssSizingPercentage(100));
 }
 
 /// A CSS sizing widget.


### PR DESCRIPTION
Without this, it's impossible to disable sizing (width, height, etc.) without disabling `display: block`.
