### PR TITLE
Fix `CssBlock` loosing stretched width on render object updated

### DIFF
--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -77,7 +77,7 @@ class WidgetFactory {
 
     return Column(
       children: children,
-      crossAxisAlignment: CrossAxisAlignment.start,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       mainAxisSize: MainAxisSize.min,
       textDirection: tsh.textDirection,
     );

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -77,7 +77,7 @@ class WidgetFactory {
 
     return Column(
       children: children,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
+      crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
       textDirection: tsh.textDirection,
     );

--- a/packages/core/lib/src/widgets/css_sizing.dart
+++ b/packages/core/lib/src/widgets/css_sizing.dart
@@ -10,9 +10,15 @@ class CssBlock extends CssSizing {
       : assert(child != null),
         super(child: child, key: key);
 
+  CssSizingValue get _100percent => const _CssSizingPercentage(100);
+
   @override
   _RenderCssSizing createRenderObject(BuildContext _) =>
-      _RenderCssSizing(preferredWidth: const _CssSizingPercentage(100));
+      _RenderCssSizing(preferredWidth: _100percent);
+
+  @override
+  void updateRenderObject(BuildContext _, _RenderCssSizing renderObject) =>
+      renderObject.setPreferredSize(null, _100percent, null);
 }
 
 /// A CSS sizing widget.


### PR DESCRIPTION
Related to #356, #359. 