### PR TITLE
Add `dom.Element.styles` getter

### DIFF
--- a/packages/core/lib/src/core_data.dart
+++ b/packages/core/lib/src/core_data.dart
@@ -30,12 +30,12 @@ abstract class BuildMetadata {
 
   /// The inline styles.
   ///
-  /// These are usually collected from:
+  /// These are collected from:
   ///
   /// - [WidgetFactory.parse] or [BuildOp.onChild] by calling `meta[key] = value`
   /// - [BuildOp.defaultStyles] returning a map
   /// - Attribute `style` of [domElement]
-  Iterable<MapEntry<String, String>> get styles;
+  List<InlineStyle> get styles;
 
   /// Returns `true` if subtree will be built.
   ///

--- a/packages/core/lib/src/core_helpers.dart
+++ b/packages/core/lib/src/core_helpers.dart
@@ -41,6 +41,49 @@ typedef CustomStylesBuilder = Map<String, String> Function(dom.Element element);
 /// For those needs, a custom [WidgetFactory] is the way to go.
 typedef CustomWidgetBuilder = Widget Function(dom.Element element);
 
+final _domElementStyles = Expando<List<InlineStyle>>();
+
+final _domElementStyleRegExp = RegExp(r'([a-zA-Z\-]+)\s*:\s*([^;]*)');
+
+extension DomElementExtension on dom.Element {
+  /// Returns parsed [InlineStyle]s from the element's `style` attribute.
+  ///
+  /// This is different from [BuildMetadata.styles] as it doesn't include
+  /// runtime additions from [WidgetFactory] or [BuildOp]s.
+  List<InlineStyle> get styles {
+    final result = _domElementStyles[this];
+    if (result != null) return result;
+
+    if (!attributes.containsKey('style')) {
+      return _domElementStyles[this] = const [];
+    }
+
+    return _domElementStyles[this] = _domElementStyleRegExp
+        .allMatches(attributes['style'])
+        .map((m) => InlineStyle(m[1].trim(), m[2].trim()))
+        .toList(growable: false);
+  }
+}
+
+final _domElementStyleValuesRegExp = RegExp(r'\s+');
+
+/// An inline style key value pair.
+class InlineStyle {
+  /// The key.
+  final String key;
+
+  /// The value.
+  ///
+  /// Use [values] for tokenized strings.
+  final String value;
+
+  /// Creates a key value pair.
+  InlineStyle(this.key, this.value);
+
+  /// The tokenized values.
+  List<String> get values => value.split(_domElementStyleValuesRegExp);
+}
+
 /// A set of values that should trigger rebuild.
 class RebuildTriggers {
   final List _values;

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -16,6 +16,7 @@ class WidgetFactory {
   BuildOp _styleMargin;
   BuildOp _stylePadding;
   BuildOp _styleSizing;
+  BuildOp _styleTextDecoration;
   BuildOp _styleVerticalAlign;
   BuildOp _tagA;
   BuildOp _tagBr;
@@ -686,8 +687,15 @@ class WidgetFactory {
         break;
 
       case kCssTextDecoration:
-        final textDeco = TextDeco.tryParse(value);
-        if (textDeco != null) meta.tsb(TextStyleOps.textDeco, textDeco);
+        _styleTextDecoration ??= BuildOp(onTree: (meta, _) {
+          for (final style in meta.styles) {
+            if (style.key == kCssTextDecoration) {
+              final textDeco = TextDeco.tryParse(style.values);
+              if (textDeco != null) meta.tsb(TextStyleOps.textDeco, textDeco);
+            }
+          }
+        });
+        meta.register(_styleTextDecoration);
         break;
 
       case kCssTextOverflow:

--- a/packages/core/lib/src/internal/core_parser.dart
+++ b/packages/core/lib/src/internal/core_parser.dart
@@ -7,12 +7,3 @@ import '../core_data.dart';
 part 'parser/border.dart';
 part 'parser/color.dart';
 part 'parser/length.dart';
-
-final _spacingRegExp = RegExp(r'\s+');
-Iterable<String> splitCssValues(String value) => value.split(_spacingRegExp);
-
-final _attrStyleRegExp = RegExp(r'([a-zA-Z\-]+)\s*:\s*([^;]*)');
-Iterable<MapEntry<String, String>> splitAttributeStyle(String value) =>
-    _attrStyleRegExp
-        .allMatches(value)
-        .map((m) => MapEntry(m[1].trim(), m[2].trim()));

--- a/packages/core/lib/src/internal/ops/style_bg_color.dart
+++ b/packages/core/lib/src/internal/ops/style_bg_color.dart
@@ -38,8 +38,8 @@ class StyleBgColor {
           if (parsed != null) color = parsed;
           break;
         case kCssBackground:
-          for (final v in splitCssValues(style.value)) {
-            final parsed = tryParseColor(v);
+          for (final value in style.values) {
+            final parsed = tryParseColor(value);
             if (parsed != null) color = parsed;
           }
           break;

--- a/packages/core/lib/src/internal/ops/tag_table.dart
+++ b/packages/core/lib/src/internal/ops/tag_table.dart
@@ -161,14 +161,9 @@ class TagTable {
       return value;
     }
 
-    final attrs = meta.element.attributes;
-    if (attrs.containsKey('style')) {
-      for (final pair in splitAttributeStyle(attrs['style'])
-          .toList(growable: false)
-          .reversed) {
-        if (pair.key == kCssDisplay) {
-          return pair.value;
-        }
+    for (final pair in meta.element.styles.reversed) {
+      if (pair.key == kCssDisplay) {
+        return pair.value;
       }
     }
 

--- a/packages/core/lib/src/internal/ops/text_style.dart
+++ b/packages/core/lib/src/internal/ops/text_style.dart
@@ -267,9 +267,9 @@ class TextDeco {
     this.under,
   });
 
-  factory TextDeco.tryParse(String value) {
-    for (final v in splitCssValues(value)) {
-      switch (v) {
+  factory TextDeco.tryParse(List<String> values) {
+    for (final value in values) {
+      switch (value) {
         case kCssTextDecorationLineThrough:
           return TextDeco(strike: true);
         case kCssTextDecorationNone:


### PR DESCRIPTION
Implement `DomElementExtension` and introduce `InlineStyle`. Making it easier for users of this package to handle inline styles and/or customize rendering behaviors.

Related to #367
