### PR TITLE
384 compute dry layout

### DIFF
--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -29,7 +29,7 @@ jobs:
     name: Unit test
     strategy:
       matrix:
-        channel: [stable]
+        channel: [beta, stable]
     continue-on-error: ${{ matrix.channel != 'stable' }}
     runs-on: ubuntu-latest
         

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -29,7 +29,7 @@ jobs:
     name: Unit test
     strategy:
       matrix:
-        channel: [beta, stable]
+        channel: [dev, beta, stable]
     continue-on-error: ${{ matrix.channel != 'stable' }}
     runs-on: ubuntu-latest
         

--- a/packages/core/lib/src/internal/ops/tag_li.dart
+++ b/packages/core/lib/src/internal/ops/tag_li.dart
@@ -285,6 +285,23 @@ class _ListItemRenderObject extends RenderBox
   }
 
   @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    final child = firstChild;
+    final childConstraints = constraints;
+    final childData = child.parentData as _ListItemData;
+    final childSize = child.computeDryLayout(childConstraints);
+
+    final marker = childData.nextSibling;
+    final markerConstraints = childConstraints.loosen();
+    final markerSize = marker.computeDryLayout(markerConstraints);
+
+    return Size(
+      childSize.width,
+      childSize.height > 0 ? childSize.height : markerSize.height,
+    );
+  }
+
+  @override
   void setupParentData(RenderBox child) {
     if (child.parentData is! _ListItemData) {
       child.parentData = _ListItemData();
@@ -415,6 +432,11 @@ class _ListMarkerRenderObject extends RenderBox {
   @override
   void performLayout() {
     size = _textPainter.size;
+  }
+
+  @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    return _textPainter.size;
   }
 }
 

--- a/packages/core/lib/src/widgets/css_sizing.dart
+++ b/packages/core/lib/src/widgets/css_sizing.dart
@@ -278,8 +278,7 @@ class _RenderCssSizing extends RenderProxyBox {
       minWidth: 0,
       minHeight: preferredHeight,
     );
-    child.layout(ccHeight, parentUsesSize: true);
-    final sizeHeight = child.size;
+    final sizeHeight = child.computeDryLayout(ccHeight);
 
     final ccWidth = BoxConstraints(
       maxWidth: preferredWidth,
@@ -287,8 +286,7 @@ class _RenderCssSizing extends RenderProxyBox {
       minWidth: preferredWidth,
       minHeight: 0,
     );
-    child.layout(ccWidth, parentUsesSize: true);
-    final sizeWidth = child.size;
+    final sizeWidth = child.computeDryLayout(ccWidth);
 
     final childAspectRatio = sizeWidth.width / sizeWidth.height;
     if (childAspectRatio != sizeHeight.width / sizeHeight.height) {

--- a/packages/core/lib/src/widgets/html_ruby.dart
+++ b/packages/core/lib/src/widgets/html_ruby.dart
@@ -83,6 +83,23 @@ class _RubyRenderObject extends RenderBox
       defaultPaint(context, offset);
 
   @override
+  Size computeDryLayout(BoxConstraints constraints) {
+    final ruby = firstChild;
+    final rubyConstraints = constraints.loosen();
+    final rubyData = ruby.parentData as _RubyParentData;
+    final rubySize = ruby.computeDryLayout(rubyConstraints);
+
+    final rt = rubyData.nextSibling;
+    final rtConstraints = rubyConstraints.copyWith(
+        maxHeight: rubyConstraints.maxHeight - rubySize.height);
+    final rtSize = rt.computeDryLayout(rtConstraints);
+
+    final height = rubySize.height + rtSize.height;
+    final width = max(rubySize.width, rtSize.width);
+    return constraints.constrain(Size(width, height));
+  }
+
+  @override
   void performLayout() {
     final ruby = firstChild;
     final rubyConstraints = constraints.loosen();


### PR DESCRIPTION
This PR implements `computeDryLayout` for the renderboxes present in this repo.

I've followed the approach recommended in the [migration guide](https://flutter.dev/docs/release/breaking-changes/renderbox-dry-layout#migration-guide). Each implementation of `computeDryLayout` uses the same calculations in `performLayout`, but returns the computed size.

I've also reverted the commits that disabled testing on `dev` and `beta` channels to ensure this change works as expected.
