### PR TITLE
Use webViewMediaPlaybackAlwaysAllow to control autoplay on web too.

### DIFF
--- a/packages/fwfh_webview/lib/src/web_view/html.dart
+++ b/packages/fwfh_webview/lib/src/web_view/html.dart
@@ -16,6 +16,10 @@ class WebViewState extends State<WebView> {
     _iframeElement.src = widget.url;
     _iframeElement.style.border = 'none';
 
+    if (widget.mediaPlaybackAlwaysAllow) {
+      _iframeElement.allow = 'autoplay';
+    }
+
     final viewType = '$this#$hashCode';
 
     // ignore: undefined_prefixed_name


### PR DESCRIPTION
We can enable autoplay on `<iframe>` elements on the web by setting the `allow="autoplay"` attribute.  This allows YouTube videos to play automatically.

