### PR TITLE
Add image loading builder to core widget factory

### DIFF
--- a/demo_app/lib/screens/photo_view.dart
+++ b/demo_app/lib/screens/photo_view.dart
@@ -71,13 +71,13 @@ class _InlinePhotoViewWidgetFactory extends WidgetFactory {
 class _PopupPhotoViewWidgetFactory extends WidgetFactory {
   @override
   Widget buildImageWidget(
-    BuildMetadata meta, {
-    String semanticLabel,
+    BuildMetadata meta,
+    ImageMetadata data, {
     @required String url,
   }) {
     final built = super.buildImageWidget(
       meta,
-      semanticLabel: semanticLabel,
+      data,
       url: url,
     );
 

--- a/demo_app/lib/screens/photo_view.dart
+++ b/demo_app/lib/screens/photo_view.dart
@@ -70,18 +70,11 @@ class _InlinePhotoViewWidgetFactory extends WidgetFactory {
 
 class _PopupPhotoViewWidgetFactory extends WidgetFactory {
   @override
-  Widget buildImageWidget(
-    BuildMetadata meta,
-    ImageMetadata data, {
-    @required String url,
-  }) {
-    final built = super.buildImageWidget(
-      meta,
-      data,
-      url: url,
-    );
+  Widget buildImageWidget(BuildMetadata meta, ImageSource src) {
+    final built = super.buildImageWidget(meta, src);
 
     if (built is Image) {
+      final url = src.url;
       return Builder(
         builder: (context) => GestureDetector(
           onTap: () => Navigator.of(context).push(MaterialPageRoute(

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -197,12 +197,18 @@ class WidgetFactory {
     if (provider == null) return null;
 
     return Image(
-      errorBuilder: (_, error, __) {
+      errorBuilder: (context, error, stackTrace) {
         print('$provider error: $error');
-        final text = semanticLabel ?? '❌';
-        return Text(text);
+        return imageErrorBuilder(
+          context,
+          error,
+          stackTrace,
+          semanticLabel,
+          meta,
+        );
       },
-      loadingBuilder: imageLoadingBuilder,
+      loadingBuilder: (context, child, loadingProgress) =>
+          imageLoadingBuilder(context, child, loadingProgress, meta),
       excludeFromSemantics: semanticLabel == null,
       fit: BoxFit.fill,
       image: provider,
@@ -215,9 +221,22 @@ class WidgetFactory {
     BuildContext context,
     Widget child,
     ImageChunkEvent? loadingProgress,
+    BuildMetadata meta,
   ) {
     if (loadingProgress == null) return child;
     return const SizedBox.shrink();
+  }
+
+  /// Builder for error widget if an error occurs during image loading.
+  Widget imageErrorBuilder(
+    BuildContext context,
+    Object error,
+    StackTrace? stackTrace,
+    String? semanticLabel,
+    BuildMetadata meta,
+  ) {
+    final text = semanticLabel ?? '❌';
+    return Text(text);
   }
 
   /// Builds marker widget for a list item.

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -202,11 +202,22 @@ class WidgetFactory {
         final text = semanticLabel ?? '❌';
         return Text(text);
       },
+      loadingBuilder: imageLoadingBuilder,
       excludeFromSemantics: semanticLabel == null,
       fit: BoxFit.fill,
       image: provider,
       semanticLabel: semanticLabel,
     );
+  }
+
+  /// Builder for loading widget while image is loading.
+  Widget imageLoadingBuilder(
+    BuildContext context,
+    Widget child,
+    ImageChunkEvent? loadingProgress,
+  ) {
+    if (loadingProgress == null) return child;
+    return const SizedBox.shrink();
   }
 
   /// Builds marker widget for a list item.

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -152,7 +152,7 @@ class WidgetFactory {
     final src = data.sources.isNotEmpty ? data.sources.first : null;
     if (src == null) return null;
 
-    var built = buildImageWidget(meta, data, url: src.url);
+    var built = buildImageWidget(meta, src);
 
     final title = data.title;
     if (built != null && title != null) {
@@ -175,11 +175,9 @@ class WidgetFactory {
   }
 
   /// Builds [Image].
-  Widget? buildImageWidget(
-    BuildMetadata meta,
-    ImageMetadata data, {
-    required String url,
-  }) {
+  Widget? buildImageWidget(BuildMetadata meta, ImageSource src) {
+    final url = src.url;
+
     late final ImageProvider? provider;
     if (url.startsWith('asset:')) {
       provider = imageProviderFromAsset(url);
@@ -192,20 +190,11 @@ class WidgetFactory {
     }
     if (provider == null) return null;
 
-    final semanticLabel = data.alt ?? data.title;
+    final image = src.image;
+    final semanticLabel = image?.alt ?? image?.title;
     return Image(
-      errorBuilder: (context, error, stackTrace) {
-        print('$provider error: $error');
-        return imageErrorBuilder(
-          context,
-          error,
-          stackTrace,
-          meta,
-          data,
-        );
-      },
-      loadingBuilder: (context, child, loadingProgress) =>
-          imageLoadingBuilder(context, child, loadingProgress, meta),
+      errorBuilder: (_1, _2, _3) => imageErrorBuilder(_1, _2, _3, src),
+      loadingBuilder: (_1, _2, _3) => imageLoadingBuilder(_1, _2, _3, src),
       excludeFromSemantics: semanticLabel == null,
       fit: BoxFit.fill,
       image: provider,
@@ -218,7 +207,7 @@ class WidgetFactory {
     BuildContext context,
     Widget child,
     ImageChunkEvent? loadingProgress,
-    BuildMetadata meta,
+    ImageSource src,
   ) {
     if (loadingProgress == null) return child;
     return const SizedBox.shrink();
@@ -229,10 +218,10 @@ class WidgetFactory {
     BuildContext context,
     Object error,
     StackTrace? stackTrace,
-    BuildMetadata meta,
-    ImageMetadata data,
+    ImageSource src,
   ) {
-    final semanticLabel = data.alt ?? data.title;
+    final image = src.image;
+    final semanticLabel = image?.alt ?? image?.title;
     final text = semanticLabel ?? '❌';
     return Text(text);
   }

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -152,11 +152,7 @@ class WidgetFactory {
     final src = data.sources.isNotEmpty ? data.sources.first : null;
     if (src == null) return null;
 
-    var built = buildImageWidget(
-      meta,
-      semanticLabel: data.alt ?? data.title,
-      url: src.url,
-    );
+    var built = buildImageWidget(meta, data, url: src.url);
 
     final title = data.title;
     if (built != null && title != null) {
@@ -180,8 +176,8 @@ class WidgetFactory {
 
   /// Builds [Image].
   Widget? buildImageWidget(
-    BuildMetadata meta, {
-    String? semanticLabel,
+    BuildMetadata meta,
+    ImageMetadata data, {
     required String url,
   }) {
     late final ImageProvider? provider;
@@ -196,6 +192,7 @@ class WidgetFactory {
     }
     if (provider == null) return null;
 
+    final semanticLabel = data.alt ?? data.title;
     return Image(
       errorBuilder: (context, error, stackTrace) {
         print('$provider error: $error');
@@ -203,8 +200,8 @@ class WidgetFactory {
           context,
           error,
           stackTrace,
-          semanticLabel,
           meta,
+          data,
         );
       },
       loadingBuilder: (context, child, loadingProgress) =>
@@ -232,9 +229,10 @@ class WidgetFactory {
     BuildContext context,
     Object error,
     StackTrace? stackTrace,
-    String? semanticLabel,
     BuildMetadata meta,
+    ImageMetadata data,
   ) {
+    final semanticLabel = data.alt ?? data.title;
     final text = semanticLabel ?? '❌';
     return Text(text);
   }

--- a/packages/core/lib/src/data/image.dart
+++ b/packages/core/lib/src/data/image.dart
@@ -13,7 +13,11 @@ class ImageMetadata {
   final String? title;
 
   /// Creates an image.
-  ImageMetadata({this.alt, required this.sources, this.title});
+  ImageMetadata({this.alt, required this.sources, this.title}) {
+    for (final source in sources) {
+      _imageMetas[source] = this;
+    }
+  }
 }
 
 /// An image source.
@@ -30,4 +34,9 @@ class ImageSource {
 
   /// Creates a source.
   ImageSource(this.url, {this.height, this.width});
+
+  /// The parent [ImageMetadata].
+  ImageMetadata? get image => _imageMetas[this];
 }
+
+final _imageMetas = Expando<ImageMetadata>();

--- a/packages/fwfh_svg/lib/src/svg_factory.dart
+++ b/packages/fwfh_svg/lib/src/svg_factory.dart
@@ -10,11 +10,9 @@ mixin SvgFactory on WidgetFactory {
   BuildOp? _tagSvg;
 
   @override
-  Widget? buildImageWidget(
-    BuildMetadata meta,
-    ImageMetadata data, {
-    required String url,
-  }) {
+  Widget? buildImageWidget(BuildMetadata meta, ImageSource src) {
+    final url = src.url;
+
     PictureProvider? provider;
     if (url.startsWith('data:image/svg+xml')) {
       provider = imageSvgFromDataUri(url);
@@ -29,13 +27,10 @@ mixin SvgFactory on WidgetFactory {
     }
 
     if (provider == null) {
-      return super.buildImageWidget(
-        meta,
-        data,
-        url: url,
-      );
+      return super.buildImageWidget(meta, src);
     }
-    final semanticLabel = data.alt ?? data.title;
+    final image = src.image;
+    final semanticLabel = image?.alt ?? image?.title;
 
     return SvgPicture(
       provider,

--- a/packages/fwfh_svg/lib/src/svg_factory.dart
+++ b/packages/fwfh_svg/lib/src/svg_factory.dart
@@ -11,8 +11,8 @@ mixin SvgFactory on WidgetFactory {
 
   @override
   Widget? buildImageWidget(
-    BuildMetadata meta, {
-    String? semanticLabel,
+    BuildMetadata meta,
+    ImageMetadata data, {
     required String url,
   }) {
     PictureProvider? provider;
@@ -31,10 +31,11 @@ mixin SvgFactory on WidgetFactory {
     if (provider == null) {
       return super.buildImageWidget(
         meta,
-        semanticLabel: semanticLabel,
+        data,
         url: url,
       );
     }
+    final semanticLabel = data.alt ?? data.title;
 
     return SvgPicture(
       provider,


### PR DESCRIPTION
This pull request adds an image loading builder to the `CoreWidgetFactory`. With the help of this it is possible to adjust the loading behavior of the images for example with a loading indicator or a loading shimmer. The default behavior does not change, because a sized box with the height and width of 0 is returned.

Such a loading widget is especially useful if the HTML widget is built into a list and not all images are loaded directly. Also in columns with a weak internet connection or many images a loading widget is advantageous.

A shimmer builder for example would look like this within the app:

```dart
@override
Widget imageLoadingBuilder(
  BuildContext context,
  Widget child,
  ImageChunkEvent? loadingProgress,
) {
  if (loadingProgress == null) return child;
  return Shimmer.fromColors(
    baseColor: const Color(0xFFBDC0D1),
    highlightColor: const Color(0xFFBDC0D1),
    child: Container(
      width: double.infinity,
      height: double.infinity,
      decoration: const BoxDecoration(
        color: Colors.white,
      ),
    ),
  );
}
```

Alternatively to the changes in the pull request, instead of the loading builder, we could just overwrite the loading widget. The code would then look like this:

```dart
loadingBuilder: (context, child, loadingProgress) {
  if (loadingProgress == null) return child;
  return buildImageLoadingWidget(context, loadingProgress);
},
```

```dart
/// Builds loading widget for an image.
Widget buildImageLoadingWidget(
  BuildContext context,
  ImageChunkEvent? loadingProgress,
) =>
    const SizedBox.shrink();
```