### PR TITLE
Add hybrid composition toggle to WebViewFactory for Android

### DIFF
--- a/packages/fwfh_webview/lib/src/web_view/io.dart
+++ b/packages/fwfh_webview/lib/src/web_view/io.dart
@@ -17,6 +17,11 @@ class WebViewState extends State<WebView> {
     super.initState();
     _aspectRatio = widget.aspectRatio;
 
+    if (widget.useHybridCompositionForAndroid &&
+        defaultTargetPlatform == TargetPlatform.android) {
+      lib.WebView.platform = lib.SurfaceAndroidWebView();
+    }
+
     if (widget.unsupportedWorkaroundForIssue37) {
       _issue37 = _Issue37(this);
       WidgetsBinding.instance?.addObserver(_issue37!);

--- a/packages/fwfh_webview/lib/src/web_view/web_view.dart
+++ b/packages/fwfh_webview/lib/src/web_view/web_view.dart
@@ -86,6 +86,16 @@ class WebView extends StatefulWidget {
   /// {@endtemplate}
   final String? userAgent;
 
+  /// {@template web_view.hybridComposition}
+  /// Activates Hybrid Composition for Android WebViews.
+  ///
+  /// On Android versions prior to Android 10 Hybrid Composition
+  /// has some performance drawbacks.
+  ///
+  /// Default: `false`.
+  /// {@endtemplate}
+  final bool useHybridCompositionForAndroid;
+
   /// Creates a web view.
   WebView(
     this.url, {
@@ -103,6 +113,7 @@ class WebView extends StatefulWidget {
     this.unsupportedWorkaroundForIssue37 = true,
     this.unsupportedWorkaroundForIssue375 = true,
     this.userAgent,
+    this.useHybridCompositionForAndroid = false,
     Key? key,
   })  : autoResize = !js ? false : autoResize ?? js,
         super(key: key);

--- a/packages/fwfh_webview/lib/src/web_view_factory.dart
+++ b/packages/fwfh_webview/lib/src/web_view_factory.dart
@@ -25,6 +25,9 @@ mixin WebViewFactory on WidgetFactory {
   /// {@macro web_view.userAgent}
   String? get webViewUserAgent => null;
 
+  /// {@macro web_view.hybridComposition}
+  bool get useHybridCompositionForAndroid => false;
+
   /// Builds [WebView].
   ///
   /// JavaScript is only enabled if [webViewJs] is turned on
@@ -57,6 +60,7 @@ mixin WebViewFactory on WidgetFactory {
       js: js,
       mediaPlaybackAlwaysAllow: webViewMediaPlaybackAlwaysAllow,
       userAgent: webViewUserAgent,
+      useHybridCompositionForAndroid: useHybridCompositionForAndroid,
     );
   }
 


### PR DESCRIPTION
This pull request adds the toggle `useHybridCompositionForAndroid` for hybrid composition for Android web views to the `WebViewFactory`. 

The default value for the new toggle is false, since the performance for Android 9 and below is really bad. But on Android 10 and higher there are a lot of advantages. More information regarding hybrid composition can be found [here](https://flutter.dev/docs/development/platform-integration/platform-views#performance).

In our app we check the Android version using [device_info](https://pub.dev/packages/device_info) and enable Hybrid Composition for WebViews for Android 10 and higher. I think it is a great advantage to be able to enable or disable Hybrid Composition for the WebViews via the factories.

I think we can also use it to deactivate `unsupportedWorkaroundForIssue375` if the user activates Hybrid Composition. But I haven't built that in yet, because I'm waiting for a response here :)