### PR TITLE
Add placeholder for cached network images

### DIFF
--- a/packages/core/test/_.dart
+++ b/packages/core/test/_.dart
@@ -9,8 +9,8 @@ const kColor = Color(0xFF001234);
 const kColorAccent = Color(0xFF123456);
 
 // https://stackoverflow.com/questions/6018611/smallest-data-uri-image-possible-for-a-transparent-image
-const kDataUri =
-    'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+const kDataBase64 = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+const kDataUri = 'data:image/gif;base64,$kDataBase64';
 
 final hwKey = GlobalKey<State<HtmlWidget>>();
 

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -33,9 +33,11 @@ dependency_overrides:
     path: ../fwfh_webview
 
 dev_dependencies:
+  file:
   flutter_test:
     sdk: flutter
   golden_toolkit: any
+  mocktail: any
   network_image_mock: any
   pedantic: any
 

--- a/packages/enhanced/test/_.dart
+++ b/packages/enhanced/test/_.dart
@@ -3,6 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
 
 import '../../core/test/_.dart' as helper;
+import '../../fwfh_cached_network_image/test/_.dart'
+    as fwfh_cached_network_image;
 import '../../fwfh_chewie/test/_.dart' as fwfh_chewie;
 import '../../fwfh_svg/test/_.dart' as fwfh_svg;
 import '../../fwfh_webview/test/_.dart' as fwfh_webview;
@@ -16,7 +18,9 @@ final hwKey = helper.hwKey;
 final buildCurrentState = helper.buildCurrentState;
 
 String? _explainer(helper.Explainer parent, Widget widget) {
-  return fwfh_chewie.videoPlayerExplainer(parent, widget) ??
+  return fwfh_cached_network_image.cachedNetworkImageExplainer(
+          parent, widget) ??
+      fwfh_chewie.videoPlayerExplainer(parent, widget) ??
       fwfh_svg.svgExplainer(parent, widget) ??
       fwfh_webview.webViewExplainer(parent, widget);
 }

--- a/packages/enhanced/test/config_test.dart
+++ b/packages/enhanced/test/config_test.dart
@@ -300,9 +300,8 @@ void main() {
       expect(
           explained,
           equals('[CssSizing:height≥0.0,height=auto,width≥0.0,width=auto,child='
-              '[Image:image=CachedNetworkImageProvider("http://base.com/path/image.png", scale: 1.0),'
-              'semanticLabel=image dot png'
-              ']]'));
+              '[CachedNetworkImage:imageUrl=http://base.com/path/image.png]'
+              ']'));
     });
   });
 

--- a/packages/fwfh_cached_network_image/lib/src/cached_network_image_factory.dart
+++ b/packages/fwfh_cached_network_image/lib/src/cached_network_image_factory.dart
@@ -5,6 +5,28 @@ import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart
 /// A mixin that can render IMG with `cached_network_image` plugin.
 mixin CachedNetworkImageFactory on WidgetFactory {
   @override
-  ImageProvider? imageProviderFromNetwork(String url) =>
-      url.isNotEmpty ? CachedNetworkImageProvider(url) : null;
+  Widget? buildImageWidget(BuildMetadata meta, ImageSource src) {
+    final url = src.url;
+
+    if (url.isEmpty) return null;
+
+    // Use default image loading for assets, data images and files
+    if (url.startsWith('asset:') ||
+        url.startsWith('data:image/') ||
+        url.startsWith('file:')) {
+      return super.buildImageWidget(meta, src);
+    }
+
+    return CachedNetworkImage(
+      imageUrl: url,
+      fit: BoxFit.fill,
+      placeholder: (context, url) => imageLoadingBuilder(
+        context,
+        Container(),
+        ImageChunkEvent(cumulativeBytesLoaded: 1, expectedTotalBytes: 1),
+        src,
+      ),
+      errorWidget: (_1, _2, _3) => imageErrorBuilder(_1, _3, null, src),
+    );
+  }
 }

--- a/packages/fwfh_cached_network_image/lib/src/cached_network_image_factory.dart
+++ b/packages/fwfh_cached_network_image/lib/src/cached_network_image_factory.dart
@@ -17,14 +17,14 @@ mixin CachedNetworkImageFactory on WidgetFactory {
       fit: BoxFit.fill,
       imageUrl: url,
       progressIndicatorBuilder: (context, _, progress) => imageLoadingBuilder(
-          context,
-          const SizedBox.shrink(),
-          ImageChunkEvent(
-            cumulativeBytesLoaded: progress.downloaded,
-            expectedTotalBytes: progress.totalSize,
-          ),
-          src,
+        context,
+        const SizedBox.shrink(),
+        ImageChunkEvent(
+          cumulativeBytesLoaded: progress.downloaded,
+          expectedTotalBytes: progress.totalSize,
         ),
+        src,
+      ),
     );
   }
 }

--- a/packages/fwfh_cached_network_image/lib/src/cached_network_image_factory.dart
+++ b/packages/fwfh_cached_network_image/lib/src/cached_network_image_factory.dart
@@ -7,26 +7,24 @@ mixin CachedNetworkImageFactory on WidgetFactory {
   @override
   Widget? buildImageWidget(BuildMetadata meta, ImageSource src) {
     final url = src.url;
-
-    if (url.isEmpty) return null;
-
-    // Use default image loading for assets, data images and files
-    if (url.startsWith('asset:') ||
-        url.startsWith('data:image/') ||
-        url.startsWith('file:')) {
+    if (!url.startsWith(RegExp('https?://'))) {
       return super.buildImageWidget(meta, src);
     }
 
     return CachedNetworkImage(
-      imageUrl: url,
+      errorWidget: (context, _, error) =>
+          imageErrorBuilder(context, error, null, src),
       fit: BoxFit.fill,
-      placeholder: (context, url) => imageLoadingBuilder(
-        context,
-        Container(),
-        ImageChunkEvent(cumulativeBytesLoaded: 1, expectedTotalBytes: 1),
-        src,
-      ),
-      errorWidget: (_1, _2, _3) => imageErrorBuilder(_1, _3, null, src),
+      imageUrl: url,
+      progressIndicatorBuilder: (context, _, progress) => imageLoadingBuilder(
+          context,
+          const SizedBox.shrink(),
+          ImageChunkEvent(
+            cumulativeBytesLoaded: progress.downloaded,
+            expectedTotalBytes: progress.totalSize,
+          ),
+          src,
+        ),
     );
   }
 }

--- a/packages/fwfh_cached_network_image/lib/src/cached_network_image_factory.dart
+++ b/packages/fwfh_cached_network_image/lib/src/cached_network_image_factory.dart
@@ -1,9 +1,13 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 
 /// A mixin that can render IMG with `cached_network_image` plugin.
 mixin CachedNetworkImageFactory on WidgetFactory {
+  /// Uses a custom cache manager.
+  BaseCacheManager? get cacheManager => null;
+
   @override
   Widget? buildImageWidget(BuildMetadata meta, ImageSource src) {
     final url = src.url;
@@ -12,6 +16,7 @@ mixin CachedNetworkImageFactory on WidgetFactory {
     }
 
     return CachedNetworkImage(
+      cacheManager: cacheManager,
       errorWidget: (context, _, error) =>
           imageErrorBuilder(context, error, null, src),
       fit: BoxFit.fill,

--- a/packages/fwfh_cached_network_image/pubspec.yaml
+++ b/packages/fwfh_cached_network_image/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   cached_network_image: ^3.0.0
   flutter:
     sdk: flutter
+  flutter_cache_manager: ^3.0.0
   flutter_widget_from_html_core: ">=0.6.0 <0.8.0"
 
 dependency_overrides:
@@ -18,6 +19,8 @@ dependency_overrides:
     path: ../core
 
 dev_dependencies:
+  file: any
   flutter_test:
     sdk: flutter
+  mocktail: any
   pedantic: any

--- a/packages/fwfh_cached_network_image/test/_.dart
+++ b/packages/fwfh_cached_network_image/test/_.dart
@@ -1,0 +1,31 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:fwfh_cached_network_image/fwfh_cached_network_image.dart';
+
+import '../../core/test/_.dart' as helper;
+
+final kDataUri = helper.kDataUri;
+
+String? cachedNetworkImageExplainer(helper.Explainer parent, Widget widget) {
+  if (widget is CachedNetworkImage) {
+    return '[CachedNetworkImage:imageUrl=${widget.imageUrl}]';
+  }
+
+  return null;
+}
+
+Future<String> explain(WidgetTester tester, String html) async =>
+    helper.explain(
+      tester,
+      null,
+      explainer: cachedNetworkImageExplainer,
+      hw: HtmlWidget(
+        html,
+        key: helper.hwKey,
+        factoryBuilder: () => _WidgetFactory(),
+      ),
+    );
+
+class _WidgetFactory extends WidgetFactory with CachedNetworkImageFactory {}

--- a/packages/fwfh_cached_network_image/test/_.dart
+++ b/packages/fwfh_cached_network_image/test/_.dart
@@ -1,8 +1,13 @@
+import 'dart:convert';
+
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:flutter/widgets.dart';
+import 'package:file/memory.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 import 'package:fwfh_cached_network_image/fwfh_cached_network_image.dart';
+import 'package:mocktail/mocktail.dart';
 
 import '../../core/test/_.dart' as helper;
 
@@ -16,16 +21,73 @@ String? cachedNetworkImageExplainer(helper.Explainer parent, Widget widget) {
   return null;
 }
 
-Future<String> explain(WidgetTester tester, String html) async =>
-    helper.explain(
-      tester,
-      null,
-      explainer: cachedNetworkImageExplainer,
-      hw: HtmlWidget(
-        html,
-        key: helper.hwKey,
-        factoryBuilder: () => _WidgetFactory(),
-      ),
-    );
+Future<String> explain(
+  WidgetTester tester,
+  String html, {
+  bool useExplainer = true,
+}) async {
+  await helper.explain(
+    tester,
+    null,
+    explainer: cachedNetworkImageExplainer,
+    hw: HtmlWidget(
+      html,
+      key: helper.hwKey,
+      factoryBuilder: () => _WidgetFactory(),
+    ),
+    useExplainer: useExplainer,
+  );
 
-class _WidgetFactory extends WidgetFactory with CachedNetworkImageFactory {}
+  await tester.runAsync(() => Future.delayed(const Duration(milliseconds: 10)));
+  await tester.pump();
+
+  return helper.explainWithoutPumping(
+    explainer: cachedNetworkImageExplainer,
+    useExplainer: useExplainer,
+  );
+}
+
+class _MockCacheManager extends Mock implements CacheManager {}
+
+class _WidgetFactory extends WidgetFactory with CachedNetworkImageFactory {
+  @override
+  BaseCacheManager? get cacheManager {
+    final manager = _MockCacheManager();
+    final ttl = DateTime.now().add(const Duration(days: 1));
+
+    when(() => manager.getFileStream(
+          any(),
+          headers: any(named: 'headers'),
+          withProgress: any(named: 'withProgress'),
+        )).thenAnswer((invocation) async* {
+      final String url = invocation.positionalArguments[0];
+      final uri = Uri.parse(url);
+      final fileName = uri.pathSegments.last;
+
+      switch (fileName) {
+        case 'transparent.gif':
+          final data = base64Decode(helper.kDataBase64);
+          final file = MemoryFileSystem().file(fileName)
+            ..writeAsBytesSync(data.toList(growable: false));
+          yield FileInfo(file, FileSource.Cache, ttl, url);
+          break;
+        case 'error.jpg':
+          final file = MemoryFileSystem().file(fileName)..writeAsStringSync('');
+          yield FileInfo(file, FileSource.Cache, ttl, url);
+      }
+    });
+
+    return manager;
+  }
+
+  @override
+  Widget imageLoadingBuilder(
+    BuildContext context,
+    Widget child,
+    ImageChunkEvent? loadingProgress,
+    ImageSource src,
+  ) {
+    if (loadingProgress == null) return child;
+    return const CircularProgressIndicator.adaptive();
+  }
+}

--- a/packages/fwfh_cached_network_image/test/cached_network_image_factory_test.dart
+++ b/packages/fwfh_cached_network_image/test/cached_network_image_factory_test.dart
@@ -3,9 +3,10 @@ import 'package:flutter_test/flutter_test.dart';
 import '_.dart';
 
 void main() {
-  testWidgets('renders IMG tag', (WidgetTester tester) async {
-    final sizingConstraints = 'height≥0.0,height=auto,width≥0.0,width=auto';
-    final src = 'http://domain.com/image.png';
+  final sizingConstraints = 'height≥0.0,height=auto,width≥0.0,width=auto';
+  final src = 'http://domain.com/transparent.gif';
+
+  testWidgets('renders CachedNetworkImage', (WidgetTester tester) async {
     final html = '<img src="$src" />';
     final explained = await explain(tester, html);
     expect(
@@ -14,5 +15,38 @@ void main() {
           '[CachedNetworkImage:imageUrl=$src]'
           ']'),
     );
+  });
+
+  testWidgets('renders Image for data uri', (WidgetTester tester) async {
+    final html = '<img src="$kDataUri" />';
+    final explained = (await explain(tester, html))
+        .replaceAll(RegExp(r'Uint8List#[0-9a-f]+,'), 'bytes,');
+    expect(
+        explained,
+        equals('[CssSizing:$sizingConstraints,child='
+            '[Image:image=MemoryImage(bytes, scale: 1.0)]'
+            ']'));
+  });
+
+  testWidgets('renders progress indicator', (WidgetTester tester) async {
+    final html = '<img src="${src}yolo" />';
+    final explained = await explain(
+      tester,
+      html,
+      useExplainer: false,
+    );
+    expect(explained, contains('CircularProgressIndicator'));
+  });
+
+  testWidgets('renders raw image', (WidgetTester tester) async {
+    final html = '<img src="$src" />';
+    final explained = await explain(tester, html, useExplainer: false);
+    expect(explained, contains('RawImage'));
+  });
+
+  testWidgets('handles error', (WidgetTester tester) async {
+    final html = '<img src="http://domain.com/error.jpg" />';
+    final explained = await explain(tester, html, useExplainer: false);
+    expect(explained, contains('Text("❌")'));
   });
 }

--- a/packages/fwfh_cached_network_image/test/cached_network_image_factory_test.dart
+++ b/packages/fwfh_cached_network_image/test/cached_network_image_factory_test.dart
@@ -1,25 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
-import 'package:fwfh_cached_network_image/fwfh_cached_network_image.dart';
 
-import '../../core/test/_.dart' as helper;
-
-Future<String> explain(
-  WidgetTester tester,
-  String html, {
-  bool webView = true,
-}) async =>
-    helper.explain(
-      tester,
-      null,
-      hw: HtmlWidget(
-        html,
-        key: helper.hwKey,
-        factoryBuilder: () => _WidgetFactory(),
-      ),
-    );
-
-class _WidgetFactory extends WidgetFactory with CachedNetworkImageFactory {}
+import '_.dart';
 
 void main() {
   testWidgets('renders IMG tag', (WidgetTester tester) async {
@@ -30,7 +11,7 @@ void main() {
     expect(
       explained,
       equals('[CssSizing:$sizingConstraints,child='
-          '[Image:image=CachedNetworkImageProvider("$src", scale: 1.0)]'
+          '[CachedNetworkImage:imageUrl=$src]'
           ']'),
     );
   });


### PR DESCRIPTION
The current implementation of the cached network images overrides only the image provider. Like this it's not possible to use the placeholder functionality of the `CachedNetworkImage`. This shows an other widget while loading the images. This is great for images shimmer and other similar widgets.

This pull request changes the behavior of loading cached network images. Instead of overriding the image provider, a CachedNetworkImage is created for links which are not assets, data images or files. Unfortunately I had to create a ImageChunkEvent with some values, because this is a required parameter of the `imageLoadingBuilder`.  
 
The pull request is meant to be an approach on how we could implement the loading builder here. Maybe there is a better way. 

At the moment we need a WidgetFactory here to make this work. It looks like this:
```dart
mixin CustomImageFactory on WidgetFactory {
  @override
  Widget? buildImageWidget(BuildMetadata meta, ImageSource src) {
    final url = src.url;

    // Use default image loading for assets and files
    if (url.startsWith('asset:') || url.startsWith('data:image/') || url.startsWith('file:')) {
      return super.buildImageWidget(meta, src);
    }

    return TMXCachedNetworkImage(
      imageUrl: url,
      fit: BoxFit.fill,
      placeholder: (_, __) => _buildImageShimmer(src),
      errorWidget: (_, __, ___) => Container(),
    );
  }

  Widget _buildImageShimmer(ImageSource src) {
    return TMXShimmer(
      child: TMXShimmerContainer(height: src.height, width: src.width),
    );
  }
}
```

With the changes from the pull request, this would no longer be necessary and we could implement the shimmer like this:
```dart
mixin CustomImageFactory on WidgetFactory {
  @override
  Widget imageLoadingBuilder(
    BuildContext context,
    Widget child,
    ImageChunkEvent? loadingProgress,
    ImageSource src,
  ) {
    if (loadingProgress == null) return child;

    return TMXShimmer(
      child: TMXShimmerContainer(height: src.height, width: src.width),
    );
  }
}
```
