### PR TITLE
Restore `computeLineMetrics` usage in Flutter web.

### DIFF
--- a/packages/core/lib/src/internal/ops/tag_li.dart
+++ b/packages/core/lib/src/internal/ops/tag_li.dart
@@ -256,11 +256,7 @@ class _ListMarkerRenderObject extends RenderBox {
   void paint(PaintingContext context, Offset offset) {
     final canvas = context.canvas;
 
-    var lineMetrics = <LineMetrics>[];
-    try {
-      lineMetrics = _textPainter.computeLineMetrics();
-    } catch (_) {/* discard error if any */}
-
+    final lineMetrics = _textPainter.computeLineMetrics();
     final m = lineMetrics.isNotEmpty ? lineMetrics.first : null;
     final center = offset +
         Offset(

--- a/packages/core/lib/src/internal/ops/tag_li.dart
+++ b/packages/core/lib/src/internal/ops/tag_li.dart
@@ -228,11 +228,21 @@ class _ListMarkerRenderObject extends RenderBox {
   }
 
   TextPainter? __textPainter;
+  final _textMetrics = <LineMetrics>[];
   TextPainter get _textPainter {
-    return __textPainter ??= TextPainter(
+    final existingPainter = __textPainter;
+    if (existingPainter != null) return existingPainter;
+
+    final newPainter = __textPainter = TextPainter(
       text: TextSpan(style: _textStyle, text: '1.'),
       textDirection: TextDirection.ltr,
     )..layout();
+
+    _textMetrics
+      ..clear()
+      ..addAll(newPainter.computeLineMetrics());
+
+    return newPainter;
   }
 
   TextStyle _textStyle;
@@ -256,8 +266,7 @@ class _ListMarkerRenderObject extends RenderBox {
   void paint(PaintingContext context, Offset offset) {
     final canvas = context.canvas;
 
-    final lineMetrics = _textPainter.computeLineMetrics();
-    final m = lineMetrics.isNotEmpty ? lineMetrics.first : null;
+    final m = _textMetrics.isNotEmpty ? _textMetrics.first : null;
     final center = offset +
         Offset(
           size.width / 2,


### PR DESCRIPTION
Closes #527