### PR TITLE
Fix missing `test/images` directory in pub.dev

### DIFF
--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1+1
+
+- Fix missing `test/images` directory
+
 ## 0.8.1
 
 - Mark enhanced `HtmlWidget.webViewXxx` properties as deprecated (#614)

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_widget_from_html
-version: 0.8.1
+version: 0.8.1+1
 description: Flutter package to render html as widgets that supports hyperlink, image, audio, video, iframe and many other tags.
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 

--- a/tool/pub-publish.sh
+++ b/tool/pub-publish.sh
@@ -30,10 +30,15 @@ function publish {
     flutter test
   fi
 
+  cat .gitignore >.pubignore
+  echo '/test/' >>.pubignore
+  yq e 'del(.flutter)' -i pubspec.yaml
+
   flutter pub publish
 
   # revert the changes
   git checkout .
+  rm .pubignore
 }
 
 (cd packages/core && publish)


### PR DESCRIPTION
Apparently Dart 2.14 added support for `.pubignore` file and changed logic around ignored files during publishing.

Related to #618
