### PR TITLE
Add important rule for custom styling

### DIFF
--- a/packages/core/lib/src/internal/builder.dart
+++ b/packages/core/lib/src/internal/builder.dart
@@ -16,6 +16,7 @@ const _asciiWhitespace = r'[\u{0009}\u{000A}\u{000C}\u{000D}\u{0020}]';
 final _regExpSpaceLeading = RegExp('^$_asciiWhitespace+', unicode: true);
 final _regExpSpaceTrailing = RegExp('$_asciiWhitespace+\$', unicode: true);
 final _regExpSpaces = RegExp('$_asciiWhitespace+', unicode: true);
+const kRuleImportant = '!important';
 
 class BuildMetadata extends core_data.BuildMetadata {
   final Iterable<BuildOp> _parentOps;
@@ -269,7 +270,10 @@ class BuildTree extends core_data.BuildTree {
     // stylings, step 2: get styles from `style` attribute
     for (final declaration in meta.element.styles) {
       meta._styles ??= [];
-      meta._styles!.add(declaration);
+
+      if (!_importantRuleExists(meta._styles!, declaration.property)) {
+        meta._styles!.add(declaration);
+      }
     }
 
     meta._stylesIsLocked = true;
@@ -280,6 +284,17 @@ class BuildTree extends core_data.BuildTree {
     wf.parseStyleDisplay(meta, meta[kCssDisplay]?.term);
 
     meta._buildOpsIsLocked = true;
+  }
+
+  bool _importantRuleExists(List<css.Declaration> styles, String newProperty) {
+    for (final css.Declaration style in styles) {
+      if (style.property == newProperty) {
+        if (style.span.text.contains(kRuleImportant)) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 
   void _customStylesBuilder(BuildMetadata meta) {


### PR DESCRIPTION
This pull requests adds the important rule for custom styling. It's related to this issue: https://github.com/daohoangson/flutter_widget_from_html/issues/733

When adding the `!important` rule to custom styling, the inline style is ignored. This allows inline styles to be overridden as in the browser.

<details>
  <summary>Example code for testing</summary>

```dart
class MyHomePage extends StatelessWidget {
  const MyHomePage();

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(
        title: const Text('HTML test'),
      ),
      body: CustomScrollView(slivers: [
        const SliverToBoxAdapter(),
        HtmlWidget(
          '''
<table style="width: 50%;">
    <tbody>
        <tr>
            <td style="width: 15.6051%;">Test row</td>
            <td style="width: 19.7054%;">Test row 2</td>
        </tr>
    </tbody>
</table>
''',
          renderMode: RenderMode.sliverList,
          customStylesBuilder: _customStylesBuilder,
        ),
      ]),
    );
  }

  Map<String, String>? _customStylesBuilder(dom.Element element) {
    if (element.localName == 'table') {
      return {'width': '100%!important'};
    }
    if (element.localName == 'td') {
      return {'width': '100%!important'};
    }
    return null;
  }
}
```
</details>

Result with this branch:

<img width="383" alt="CleanShot 2022-02-15 at 14 27 15@2x" src="https://user-images.githubusercontent.com/1169185/154071312-29f93688-2f0d-4189-ba59-0833a159a59f.png">

Result on current master:

<img width="385" alt="CleanShot 2022-02-15 at 14 27 51@2x" src="https://user-images.githubusercontent.com/1169185/154071379-01dab91c-7465-477f-af28-fe2914956cf2.png">