### PR TITLE
Fix context usage across async gaps

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+1
+
+- Fix context usage across async gaps (#835)
+
 ## 0.9.0
 
 - Requires Flutter 3.3 (#821)

--- a/packages/core/lib/src/core_html_widget.dart
+++ b/packages/core/lib/src/core_html_widget.dart
@@ -213,6 +213,9 @@ class HtmlWidgetState extends State<HtmlWidget> {
 
   Future<Widget> _buildAsync() async {
     final domNodes = await compute(_parseHtml, widget.html);
+    if (!mounted) {
+      return widget0;
+    }
 
     Timeline.startSync('Build $widget (async)');
     final built = _buildBody(this, domNodes);

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_widget_from_html_core
-version: 0.9.0
+version: 0.9.0+1
 description: Flutter package to render html as widgets that focuses on correctness and extensibility.
 homepage: https://github.com/daohoangson/flutter_widget_from_html/tree/master/packages/core
 

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0+1
+
+- Fix context usage across async gaps (#835)
+
 ## 0.9.0
 
 - Requires Flutter 3.3 (#821)

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_widget_from_html
-version: 0.9.0
+version: 0.9.0+1
 description: Flutter package to render html as widgets that supports hyperlink, image, audio, video, iframe and many other tags.
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_widget_from_html_core: ^0.9.0+1
   fwfh_cached_network_image: ^0.7.0+3
-  fwfh_chewie: ^0.7.0+2
+  fwfh_chewie: ^0.7.0+3
   fwfh_just_audio: ^0.9.0
   fwfh_svg: ^0.7.2+1
   fwfh_url_launcher: ^0.9.0

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_widget_from_html_core: ^0.9.0
+  flutter_widget_from_html_core: ^0.9.0+1
   fwfh_cached_network_image: ^0.7.0+3
   fwfh_chewie: ^0.7.0+2
   fwfh_just_audio: ^0.9.0

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   fwfh_just_audio: ^0.9.0
   fwfh_svg: ^0.7.2+1
   fwfh_url_launcher: ^0.9.0
-  fwfh_webview: ^0.6.2+4
+  fwfh_webview: ^0.6.2+5
   html: ^0.15.0
 
 dependency_overrides:

--- a/packages/fwfh_chewie/CHANGELOG.md
+++ b/packages/fwfh_chewie/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.0+3
+
+- Fix context usage across async gaps (#835)
+
 ## 0.7.0+2
 
 - Add support for flutter_widget_from_html_core@0.9.0 (#828)

--- a/packages/fwfh_chewie/lib/src/video_player/video_player.dart
+++ b/packages/fwfh_chewie/lib/src/video_player/video_player.dart
@@ -116,21 +116,30 @@ class _VideoPlayerState extends State<VideoPlayer> {
 
   Future<void> _initControllers() async {
     final vpc = _vpc = lib.VideoPlayerController.network(widget.url);
+    Object? vpcError;
     try {
       await vpc.initialize();
     } catch (error) {
-      setState(() => _error = error);
+      vpcError = error;
+    }
+
+    if (!mounted) {
       return;
     }
 
-    setState(
-      () => _controller = lib.ChewieController(
+    setState(() {
+      if (vpcError != null) {
+        _error = vpcError;
+        return;
+      }
+
+      _controller = lib.ChewieController(
         autoPlay: widget.autoplay,
         looping: widget.loop,
         placeholder: placeholder,
         showControls: widget.controls,
         videoPlayerController: vpc,
-      ),
-    );
+      );
+    });
   }
 }

--- a/packages/fwfh_chewie/pubspec.yaml
+++ b/packages/fwfh_chewie/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fwfh_chewie
-version: 0.7.0+2
+version: 0.7.0+3
 description: WidgetFactory extension to render VIDEO with the chewie plugin.
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 

--- a/packages/fwfh_webview/CHANGELOG.md
+++ b/packages/fwfh_webview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.2+5
+
+- Fix context usage across async gaps (#835)
+
 ## 0.6.2+4
 
 - Add support for flutter_widget_from_html_core@0.9.0 (#828)

--- a/packages/fwfh_webview/lib/src/web_view/io.dart
+++ b/packages/fwfh_webview/lib/src/web_view/io.dart
@@ -97,6 +97,10 @@ class WebViewState extends State<WebView> {
       eval('document.body.scrollWidth'),
       eval('document.body.scrollHeight'),
     ]);
+    if (!mounted) {
+      return;
+    }
+
     final w = double.tryParse(evals[0]) ?? 0;
     final h = double.tryParse(evals[1]) ?? 0;
 

--- a/packages/fwfh_webview/pubspec.yaml
+++ b/packages/fwfh_webview/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fwfh_webview
-version: 0.6.2+4
+version: 0.6.2+5
 description: WidgetFactory extension to render IFRAME with the official WebView plugin.
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 


### PR DESCRIPTION
When `HtmlWidget` is rendered / disposed too fast (e.g. high velocity scrolling listview), there is incorrect context usage across async gap. This PR fixes some of those.

Related to #834