### PR TITLE
Provide parent meta for `onChild`

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -225,7 +225,7 @@ The HTML string is parsed into DOM elements and each element is visited once to 
 | Step |                                                                          | Integration point                                                                                                   |
 |------|--------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | 1    | Parse                                                                    | `WidgetFactory.parse(BuildMetadata)`                                                                                |
-| 2    | Inform parents if any                                                    | `BuildOp.onChild(BuildMetadata)`                                                                                    |
+| 2    | Inform parents if any                                                    | `BuildOp.onChild(BuildMetadata, BuildMetadata)`                                                                     |
 | 3    | Populate default styling                                                 | `BuildOp.defaultStyles(Element)`                                                                                    |
 | 4    | Populate custom styling                                                  | `HtmlWidget.customStylesBuilder`                                                                                    |
 | 5    | Parse styling key+value pairs, `parseStyle` may be called multiple times | `WidgetFactory.parseStyle(BuildMetadata, String, String)`, `WidgetFactory.parseStyleDisplay(BuildMetadata, String)` |

--- a/packages/core/lib/src/core_data.dart
+++ b/packages/core/lib/src/core_data.dart
@@ -35,7 +35,7 @@ abstract class BuildMetadata {
   Iterable<BuildOp> get buildOps;
 
   /// The parents' build ops that have [BuildOp.onChild].
-  Iterable<BuildOp> get parentOps;
+  Iterable<ParentOp> get parentOps;
 
   /// The styling declarations.
   ///
@@ -101,14 +101,15 @@ class BuildOp {
   ///
   /// ```dart
   /// BuildOp(
-  ///   onChild: (childMeta) {
+  ///   onChild: (parentMeta, childMeta) {
   ///     if (!childElement.element.parent != parentMeta.element) return;
   ///     childMeta.doSomethingHere;
   ///   },
   /// );
   ///
   /// ```
-  final void Function(BuildMetadata childMeta)? onChild;
+  final void Function(BuildMetadata parentMeta, BuildMetadata childMeta)?
+      onChild;
 
   /// The callback that will be called when child elements have been processed.
   final void Function(BuildMetadata meta, BuildTree tree)? onTree;
@@ -139,4 +140,11 @@ class BuildOp {
     this.onWidgetsIsOptional = false,
     this.priority = 10,
   });
+}
+
+@immutable
+class ParentOp {
+  final BuildMetadata meta;
+  final BuildOp op;
+  const ParentOp(this.meta, this.op);
 }

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -39,11 +39,13 @@ class WidgetFactory {
   BuildOp? _tagA;
   TextStyleHtml Function(TextStyleHtml, void)? _tagAColor;
   BuildOp? _tagBr;
+  BuildOp? _tagDetails;
   BuildOp? _tagFont;
   BuildOp? _tagHr;
   BuildOp? _tagImg;
   BuildOp? _tagPre;
   BuildOp? _tagQ;
+  BuildOp? _tagRuby;
   TextStyleHtml Function(TextStyleHtml, css.Expression)? _tsbLineHeight;
   HtmlWidget? _widget;
 
@@ -760,7 +762,7 @@ class WidgetFactory {
         break;
 
       case kTagDetails:
-        meta.register(TagDetails(this, meta).op);
+        meta.register(_tagDetails ??= TagDetails(this).op);
         break;
 
       case 'dd':
@@ -886,7 +888,7 @@ class WidgetFactory {
         break;
 
       case kTagRuby:
-        meta.register(TagRuby(this, meta).op);
+        meta.register(_tagRuby ??= TagRuby(this).op);
         break;
 
       case 'script':
@@ -1106,7 +1108,7 @@ class WidgetFactory {
         meta.register(displayNone);
         break;
       case kCssDisplayTable:
-        meta.register(TagTable(this, meta).op);
+        meta.register(TagTable.notReusable(this).op);
         break;
     }
   }

--- a/packages/core/lib/src/internal/builder.dart
+++ b/packages/core/lib/src/internal/builder.dart
@@ -18,7 +18,7 @@ final _regExpSpaceTrailing = RegExp('$_asciiWhitespace+\$', unicode: true);
 final _regExpSpaces = RegExp('$_asciiWhitespace+', unicode: true);
 
 class BuildMetadata extends core_data.BuildMetadata {
-  final Iterable<BuildOp> _parentOps;
+  final Iterable<ParentOp> _parentOps;
 
   Set<BuildOp>? _buildOps;
   var _buildOpsIsLocked = false;
@@ -35,7 +35,7 @@ class BuildMetadata extends core_data.BuildMetadata {
   Iterable<BuildOp> get buildOps => _buildOps ?? const [];
 
   @override
-  Iterable<BuildOp> get parentOps => _parentOps;
+  Iterable<ParentOp> get parentOps => _parentOps;
 
   @override
   List<css.Declaration> get styles {
@@ -63,7 +63,7 @@ class BuildTree extends core_data.BuildTree {
   final CustomStylesBuilder? customStylesBuilder;
   final CustomWidgetBuilder? customWidgetBuilder;
   final core_data.BuildMetadata parentMeta;
-  final Iterable<BuildOp> parentOps;
+  final Iterable<ParentOp> parentOps;
   final WidgetFactory wf;
 
   final _built = <WidgetPlaceholder>[];
@@ -145,7 +145,7 @@ class BuildTree extends core_data.BuildTree {
   BuildTree sub({
     core_data.BuildTree? parent,
     BuildMetadata? parentMeta,
-    Iterable<BuildOp> parentOps = const [],
+    Iterable<ParentOp> parentOps = const [],
     TextStyleBuilder? tsb,
   }) =>
       BuildTree(
@@ -246,8 +246,8 @@ class BuildTree extends core_data.BuildTree {
   void _collectMetadata(BuildMetadata meta) {
     wf.parse(meta);
 
-    for (final op in meta.parentOps) {
-      op.onChild?.call(meta);
+    for (final parent in meta.parentOps) {
+      parent.op.onChild?.call(parent.meta, meta);
     }
 
     // stylings, step 1: get default styles from tag-based build ops
@@ -319,10 +319,16 @@ int _compareBuildOps(BuildOp a, BuildOp b) {
 bool _opRequiresBuildingSubtree(BuildOp op) =>
     op.onWidgets != null && !op.onWidgetsIsOptional;
 
-Iterable<BuildOp> _prepareParentOps(Iterable<BuildOp> ops, BuildMetadata meta) {
+Iterable<ParentOp> _prepareParentOps(
+  Iterable<ParentOp> inheritedParentOps,
+  BuildMetadata meta,
+) {
   // try to reuse existing list if possible
-  final withOnChild = meta.buildOps.where((op) => op.onChild != null).toList();
-  return withOnChild.isEmpty
-      ? ops
-      : List.unmodifiable([...ops, ...withOnChild]);
+  final opsWithOnChild = meta.buildOps
+      .where((op) => op.onChild != null)
+      .map((op) => ParentOp(meta, op))
+      .toList();
+  return opsWithOnChild.isEmpty
+      ? inheritedParentOps
+      : List.unmodifiable([...inheritedParentOps, ...opsWithOnChild]);
 }

--- a/packages/core/lib/src/internal/ops/tag_li.dart
+++ b/packages/core/lib/src/internal/ops/tag_li.dart
@@ -58,7 +58,7 @@ class TagLi {
 
   Map<String, String> defaultStyles(dom.Element element) {
     final attrs = element.attributes;
-    final depth = listMeta.parentOps.whereType<_TagLiListOp>().length;
+    final depth = listMeta.parentOps.where((e) => e.op is _TagLiListOp).length;
 
     final styles = {
       'padding-inline-start': '40px',
@@ -81,7 +81,7 @@ class TagLi {
     return styles;
   }
 
-  void onChild(BuildMetadata childMeta) {
+  void onChild(BuildMetadata _, BuildMetadata childMeta) {
     final e = childMeta.element;
     if (e.localName != kTagLi) {
       return;

--- a/packages/core/lib/src/internal/ops/tag_ruby.dart
+++ b/packages/core/lib/src/internal/ops/tag_ruby.dart
@@ -6,24 +6,13 @@ const kTagRt = 'rt';
 
 class TagRuby {
   late final BuildOp op;
-  final BuildMetadata rubyMeta;
   final WidgetFactory wf;
 
-  late final BuildOp _rtOp;
-
-  TagRuby(this.wf, this.rubyMeta) {
-    op = BuildOp(onChild: onChild, onTree: onTree);
-    _rtOp = BuildOp(
-      onTree: (rtMeta, rtTree) {
-        if (rtTree.isEmpty) {
-          return;
-        }
-        rtTree.isRtBit = true;
-      },
-    );
+  TagRuby(this.wf) {
+    op = BuildOp(onChild: _onChild, onTree: _onTree);
   }
 
-  void onChild(BuildMetadata childMeta) {
+  static void _onChild(BuildMetadata rubyMeta, BuildMetadata childMeta) {
     final e = childMeta.element;
     if (e.parent != rubyMeta.element) {
       return;
@@ -36,12 +25,19 @@ class TagRuby {
       case kTagRt:
         childMeta
           ..[kCssFontSize] = '0.5em'
-          ..register(_rtOp);
+          ..register(const BuildOp(onTree: _onRtTree));
         break;
     }
   }
 
-  void onTree(BuildMetadata _, BuildTree tree) {
+  static void _onRtTree(BuildMetadata _, BuildTree rtTree) {
+    if (rtTree.isEmpty) {
+      return;
+    }
+    rtTree.isRtBit = true;
+  }
+
+  void _onTree(BuildMetadata _, BuildTree tree) {
     final rubyBits = <BuildBit>[];
 
     for (final bit in tree.directChildren.toList(growable: false)) {

--- a/packages/fwfh_chewie/lib/src/chewie_factory.dart
+++ b/packages/fwfh_chewie/lib/src/chewie_factory.dart
@@ -6,6 +6,8 @@ import 'video_player/video_player.dart';
 
 /// A mixin that can build player for VIDEO.
 mixin ChewieFactory on WidgetFactory {
+  BuildOp? _tagVideo;
+
   /// Builds [VideoPlayer].
   Widget? buildVideoPlayer(
     BuildMetadata meta,
@@ -40,7 +42,7 @@ mixin ChewieFactory on WidgetFactory {
   void parse(BuildMetadata meta) {
     switch (meta.element.localName) {
       case kTagVideo:
-        meta.register(TagVideo(this, meta).op);
+        meta.register(_tagVideo ??= TagVideo(this).op);
         break;
     }
     return super.parse(meta);


### PR DESCRIPTION
BREAKING changes:

- `BuildMetadata.parentOps` now returns `ParentOp` instead of `BuildOp`
- `BuildOp.onChild` method signature