### PR TITLE
Fixed Obvious Table Text Overflows

### DIFF
--- a/packages/core/lib/src/widgets/html_table.dart
+++ b/packages/core/lib/src/widgets/html_table.dart
@@ -389,7 +389,7 @@ class _TableRenderLayouter {
             // this call is expensive, we try to avoid it as much as possible
             // width being smaller than dry size means the table is too crowded
             // calculating min to avoid breaking line in the middle of a word
-            minWidth = child.getMinIntrinsicWidth(double.infinity);
+            minWidth = min(availableWidth, child.getMinIntrinsicWidth(double.infinity));
           } catch (minWidthError, stackTrace) {
             minWidth = drySize.width;
             debugPrint('Ignored getMinIntrinsicWidth error: '

--- a/packages/core/test/tag_table_test.dart
+++ b/packages/core/test/tag_table_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 import 'package:golden_toolkit/golden_toolkit.dart';
@@ -132,6 +133,25 @@ Future<void> main() async {
       expect(explained, contains('[RichText:align=right,(:Value (+i:1))]'));
       expect(explained, contains('[RichText:align=right,(+b:Value 2)]'));
     });
+  });
+
+  testWidgets("No Overflowing Text", (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 500,
+            child: HtmlWidget("""
+    <table><tr><td>
+    <p>https://tech.slashdot.org/story/23/05/06/1715225/nvidia-details-neural-texture-compression-claims-significant-improvements?utm_source=atom1.0mainlinkanon&amp;utm_medium=feed</p>
+    </td></tr></table>"""),
+          ),
+        ),
+      ),
+    );
+
+    final RenderParagraph renderParagraph = tester.renderObject(find.byType(RichText)) as RenderParagraph;
+    expect(renderParagraph.size.width <= 500, true);
   });
 
   group('border', () {


### PR DESCRIPTION
The following HTML will overflow if not given enough width:

```
<table><tr><td>
<p>https://tech.slashdot.org/story/23/05/06/1715225/nvidia-details-neural-texture-compression-claims-significant-improvements?utm_source=atom1.0mainlinkanon&amp;utm_medium=feed</p>
</td></tr></table>
```

This is because when inside a table we use `getMinIntrinsicWidth()` to compute the minimum width and for text that will always assume no soft wrapping. The result is that if there is a line without any spaces in it like a URL the table's cells will never be smaller than that causing a potential overflow.

I'm not that happy with how I fixed it because I just made it so no single cell can be larger than the total available width. This will fix the problem for single column tables but may not solve it for multirow tables. But I don't know how better to solve it. I considered submitting a PR to Flutter to make `getMinIntrinsicWidth()` but it says this

> The minimum intrinsic width would be the width of the widest word, "Hello" or "World". If the text is rendered in an even narrower width, however, it might still not overflow. For example, maybe the rendering would put a line-break half-way through the words, as in "Hel⁞lo⁞Wor⁞ld". However, this wouldn't be a _correct_ rendering, and [computeMinIntrinsicWidth] is supposed to render the minimum width that the box could be without failing to _correctly_ paint the contents within itself.

So I'm a little confused.