### PR TITLE
Update pubspec.yaml

### DIFF
--- a/packages/fwfh_chewie/pubspec.yaml
+++ b/packages/fwfh_chewie/pubspec.yaml
@@ -8,11 +8,11 @@ environment:
   sdk: ">=2.14.0 <4.0.0"
 
 dependencies:
-  chewie: ^1.0.0
+  chewie: ^1.3.6
   flutter:
     sdk: flutter
   flutter_widget_from_html_core: ">=0.8.0 <0.11.0"
-  video_player: ^2.2.9
+  video_player: ^2.4.7
 
 dependency_overrides:
   flutter_widget_from_html_core:


### PR DESCRIPTION
Pull request create to solve this error.
The Android Gradle plugin supports only Kotlin Gradle plugin version 1.5.20 and higher.
The following dependencies do not satisfy the required version:
 project ':wakelock' -> org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.50