### PR TITLE
Add support for `HtmlWidget.tags`

### DIFF
--- a/packages/core/lib/src/core_html_widget.dart
+++ b/packages/core/lib/src/core_html_widget.dart
@@ -88,6 +88,9 @@ class HtmlWidget extends StatefulWidget {
   /// and can be put inside a `CustomScrollView`.
   final RenderMode renderMode;
 
+  /// The custom styling for tags.
+  final Map<String, BuildOp> tags;
+
   /// The default styling for text elements.
   final TextStyle? textStyle;
 
@@ -109,6 +112,7 @@ class HtmlWidget extends StatefulWidget {
     this.onTapUrl,
     List<dynamic>? rebuildTriggers,
     this.renderMode = RenderMode.column,
+    this.tags = const {},
     this.textStyle,
   })  : _rebuildTriggers = rebuildTriggers,
         super(key: key);

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -910,7 +910,7 @@ class WidgetFactory extends WidgetFactoryResetter with AnchorWidgetFactory {
           const BuildOp.v1(
             debugLabel: kTagTableCell,
             defaultStyles: _cssVerticalAlignMiddle,
-            priority: Early.tagTableCellDefaultStyles,
+            priority: Early.tagTableCellValignDefault,
           ),
         );
         break;

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -970,6 +970,11 @@ class WidgetFactory extends WidgetFactoryResetter with AnchorWidgetFactory {
           break;
       }
     }
+
+    final tagBuildOp = _widget?.tags[localName];
+    if (tagBuildOp != null) {
+      tree.register(tagBuildOp);
+    }
   }
 
   /// Parses inline style [css.Declaration] one by one.

--- a/packages/core/lib/src/internal/core_build_tree.dart
+++ b/packages/core/lib/src/internal/core_build_tree.dart
@@ -301,7 +301,7 @@ class CoreBuildTree extends BuildTree {
     for (final op in _buildOps) {
       final defaultStyles = op.defaultStyles;
       if (defaultStyles != null) {
-        _styles.insertAll(0, defaultStyles);
+        _styles.addAll(defaultStyles);
       }
     }
 

--- a/packages/core/lib/src/internal/ops/priorities.dart
+++ b/packages/core/lib/src/internal/ops/priorities.dart
@@ -63,10 +63,10 @@ class Early {
       tagTableAttributeBorderChild + _step;
   static const tagTableCaptionTextAlignCenter =
       tagTableAttributeCellPaddingChild - _step;
-  static const tagTableCellAttributeValign =
+  static const tagTableCellValignDefault =
       tagTableCaptionTextAlignCenter + _step;
-  static const tagTableCellDefaultStyles = tagTableCellAttributeValign + _step;
-  static const tagTableDisplayTable = tagTableCellDefaultStyles + _step;
+  static const tagTableCellValignParsed = tagTableCellValignDefault + _step;
+  static const tagTableDisplayTable = tagTableCellValignParsed + _step;
   static const tagTableHeaderCellDefaultStyles = tagTableDisplayTable + _step;
   static const tagTableRenderBlock = tagTableHeaderCellDefaultStyles + _step;
 }

--- a/packages/core/lib/src/internal/ops/tag_table.dart
+++ b/packages/core/lib/src/internal/ops/tag_table.dart
@@ -383,7 +383,7 @@ class _TagTableRow {
         const BuildOp.v1(
           debugLabel: kTagTableCell,
           defaultStyles: _cssVerticalAlignFromAttribute,
-          priority: Early.tagTableCellAttributeValign,
+          priority: Early.tagTableCellValignParsed,
         ),
       );
     }

--- a/packages/core/test/core_config_test.dart
+++ b/packages/core/test/core_config_test.dart
@@ -620,21 +620,57 @@ void main() {
   });
 
   group('tags', () {
-    const html = 'Hello <foo>World</foo>!';
+    group('color: red', () {
+      const html = 'Hello <foo>World</foo>!';
 
-    testWidgets('renders without value', (WidgetTester tester) async {
-      final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
-      expect(e, equals('[RichText:(:Hello World!)]'));
+      testWidgets('renders without value', (WidgetTester tester) async {
+        final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+        expect(e, equals('[RichText:(:Hello World!)]'));
+      });
+
+      testWidgets('renders with value', (WidgetTester tester) async {
+        final explained = await explain(
+          tester,
+          HtmlWidget(
+            html,
+            key: helper.hwKey,
+            tags: {
+              'foo': BuildOp.v1(defaultStyles: (_) => {'color': 'red'})
+            },
+          ),
+        );
+        expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+      });
     });
 
-    testWidgets('renders with value', (WidgetTester tester) async {
-      final explained = await explain(
-        tester,
-        HtmlWidget(html, key: helper.hwKey, tags: {
-          'foo': BuildOp.v1(defaultStyles: (_) => {'color': 'red'})
-        }),
-      );
-      expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+    group('resets FIGURE margin', () {
+      const html = '<figure>Foo</figure>';
+
+      testWidgets('renders without value', (WidgetTester tester) async {
+        final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+        expect(
+          e,
+          equals(
+            '[Padding:(0,40,0,40),child='
+            '[CssBlock:child=[RichText:(:Foo)]]'
+            ']',
+          ),
+        );
+      });
+
+      testWidgets('renders with value', (WidgetTester tester) async {
+        final explained = await explain(
+          tester,
+          HtmlWidget(
+            html,
+            key: helper.hwKey,
+            tags: {
+              'figure': BuildOp.v1(defaultStyles: (_) => {'margin': '0'})
+            },
+          ),
+        );
+        expect(explained, equals('[CssBlock:child=[RichText:(:Foo)]]'));
+      });
     });
   });
 

--- a/packages/core/test/core_config_test.dart
+++ b/packages/core/test/core_config_test.dart
@@ -588,6 +588,25 @@ void main() {
     });
   });
 
+  group('tags', () {
+    const html = 'Hello <foo>World</foo>!';
+
+    testWidgets('renders without value', (WidgetTester tester) async {
+      final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+      expect(e, equals('[RichText:(:Hello World!)]'));
+    });
+
+    testWidgets('renders with value', (WidgetTester tester) async {
+      final explained = await explain(
+        tester,
+        HtmlWidget(html, key: helper.hwKey, tags: {
+          'foo': BuildOp.v1(defaultStyles: (_) => {'color': 'red'})
+        }),
+      );
+      expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+    });
+  });
+
   group('textStyle', () {
     const html = 'Foo';
 

--- a/packages/core/test/core_config_test.dart
+++ b/packages/core/test/core_config_test.dart
@@ -233,24 +233,55 @@ void main() {
   });
 
   group('customStylesBuilder', () {
-    const html = 'Hello <span class="name">World</span>!';
+    group('color: red', () {
+      const html = 'Hello <span class="name">World</span>!';
 
-    testWidgets('renders without value', (WidgetTester tester) async {
-      final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
-      expect(e, equals('[RichText:(:Hello World!)]'));
+      testWidgets('renders without value', (WidgetTester tester) async {
+        final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+        expect(e, equals('[RichText:(:Hello World!)]'));
+      });
+
+      testWidgets('renders with value', (WidgetTester tester) async {
+        final explained = await explain(
+          tester,
+          HtmlWidget(
+            html,
+            customStylesBuilder: (e) =>
+                e.classes.contains('name') ? {'color': 'red'} : null,
+            key: helper.hwKey,
+          ),
+        );
+        expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+      });
     });
 
-    testWidgets('renders with value', (WidgetTester tester) async {
-      final explained = await explain(
-        tester,
-        HtmlWidget(
-          html,
-          customStylesBuilder: (e) =>
-              e.classes.contains('name') ? {'color': 'red'} : null,
-          key: helper.hwKey,
-        ),
-      );
-      expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+    group('resets FIGURE margin', () {
+      const html = '<figure class="name">Foo</figure>';
+
+      testWidgets('renders without value', (WidgetTester tester) async {
+        final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+        expect(
+          e,
+          equals(
+            '[Padding:(0,40,0,40),child='
+            '[CssBlock:child=[RichText:(:Foo)]]'
+            ']',
+          ),
+        );
+      });
+
+      testWidgets('renders with value', (WidgetTester tester) async {
+        final explained = await explain(
+          tester,
+          HtmlWidget(
+            html,
+            customStylesBuilder: (e) =>
+                e.classes.contains('name') ? {'margin': '0'} : null,
+            key: helper.hwKey,
+          ),
+        );
+        expect(explained, equals('[CssBlock:child=[RichText:(:Foo)]]'));
+      });
     });
   });
 

--- a/packages/core/test/src/core_legacy_test.dart
+++ b/packages/core/test/src/core_legacy_test.dart
@@ -65,7 +65,7 @@ void main() {
         expect(explained, equals('[RichText:(#FF00FF00:Foo)]'));
       });
 
-      testWidgets('renders defaultStyles in reversed', (tester) async {
+      testWidgets('renders defaultStyles with priority', (tester) async {
         const html = '<span>Foo</span>';
         final explained = await explain(
           tester,
@@ -511,13 +511,13 @@ class _BuildOpDefaultStyles extends WidgetFactory {
       ..register(
         BuildOp(
           defaultStyles: (_) => {'color': '#f00'},
-          priority: 1,
+          priority: 2,
         ),
       )
       ..register(
         BuildOp(
           defaultStyles: (_) => {'color': '#0f0'},
-          priority: 2,
+          priority: 1,
         ),
       );
 

--- a/packages/enhanced/lib/src/html_widget.dart
+++ b/packages/enhanced/lib/src/html_widget.dart
@@ -27,6 +27,7 @@ class HtmlWidget extends core.HtmlWidget {
     super.onTapUrl,
     super.rebuildTriggers,
     super.renderMode,
+    super.tags,
     super.textStyle,
   }) : super(factoryBuilder: factoryBuilder ?? _getEnhancedWf);
 

--- a/packages/enhanced/test/config_test.dart
+++ b/packages/enhanced/test/config_test.dart
@@ -224,24 +224,55 @@ void main() {
   });
 
   group('customStylesBuilder', () {
-    const html = 'Hello <span class="name">World</span>!';
+    group('color: red', () {
+      const html = 'Hello <span class="name">World</span>!';
 
-    testWidgets('renders without value', (WidgetTester tester) async {
-      final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
-      expect(e, equals('[RichText:(:Hello World!)]'));
+      testWidgets('renders without value', (WidgetTester tester) async {
+        final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+        expect(e, equals('[RichText:(:Hello World!)]'));
+      });
+
+      testWidgets('renders with value', (WidgetTester tester) async {
+        final explained = await explain(
+          tester,
+          HtmlWidget(
+            html,
+            customStylesBuilder: (e) =>
+                e.classes.contains('name') ? {'color': 'red'} : null,
+            key: helper.hwKey,
+          ),
+        );
+        expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+      });
     });
 
-    testWidgets('renders with value', (WidgetTester tester) async {
-      final explained = await explain(
-        tester,
-        HtmlWidget(
-          html,
-          customStylesBuilder: (e) =>
-              e.classes.contains('name') ? {'color': 'red'} : null,
-          key: helper.hwKey,
-        ),
-      );
-      expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+    group('resets FIGURE margin', () {
+      const html = '<figure class="name">Foo</figure>';
+
+      testWidgets('renders without value', (WidgetTester tester) async {
+        final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+        expect(
+          e,
+          equals(
+            '[Padding:(0,40,0,40),child='
+            '[CssBlock:child=[RichText:(:Foo)]]'
+            ']',
+          ),
+        );
+      });
+
+      testWidgets('renders with value', (WidgetTester tester) async {
+        final explained = await explain(
+          tester,
+          HtmlWidget(
+            html,
+            customStylesBuilder: (e) =>
+                e.classes.contains('name') ? {'margin': '0'} : null,
+            key: helper.hwKey,
+          ),
+        );
+        expect(explained, equals('[CssBlock:child=[RichText:(:Foo)]]'));
+      });
     });
   });
 

--- a/packages/enhanced/test/config_test.dart
+++ b/packages/enhanced/test/config_test.dart
@@ -562,6 +562,25 @@ void main() {
     });
   });
 
+  group('tags', () {
+    const html = 'Hello <foo>World</foo>!';
+
+    testWidgets('renders without value', (WidgetTester tester) async {
+      final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+      expect(e, equals('[RichText:(:Hello World!)]'));
+    });
+
+    testWidgets('renders with value', (WidgetTester tester) async {
+      final explained = await explain(
+        tester,
+        HtmlWidget(html, key: helper.hwKey, tags: {
+          'foo': BuildOp.v1(defaultStyles: (_) => {'color': 'red'})
+        }),
+      );
+      expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+    });
+  });
+
   group('textStyle', () {
     const html = 'Foo';
 

--- a/packages/enhanced/test/config_test.dart
+++ b/packages/enhanced/test/config_test.dart
@@ -594,21 +594,57 @@ void main() {
   });
 
   group('tags', () {
-    const html = 'Hello <foo>World</foo>!';
+    group('color: red', () {
+      const html = 'Hello <foo>World</foo>!';
 
-    testWidgets('renders without value', (WidgetTester tester) async {
-      final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
-      expect(e, equals('[RichText:(:Hello World!)]'));
+      testWidgets('renders without value', (WidgetTester tester) async {
+        final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+        expect(e, equals('[RichText:(:Hello World!)]'));
+      });
+
+      testWidgets('renders with value', (WidgetTester tester) async {
+        final explained = await explain(
+          tester,
+          HtmlWidget(
+            html,
+            key: helper.hwKey,
+            tags: {
+              'foo': BuildOp.v1(defaultStyles: (_) => {'color': 'red'})
+            },
+          ),
+        );
+        expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+      });
     });
 
-    testWidgets('renders with value', (WidgetTester tester) async {
-      final explained = await explain(
-        tester,
-        HtmlWidget(html, key: helper.hwKey, tags: {
-          'foo': BuildOp.v1(defaultStyles: (_) => {'color': 'red'})
-        }),
-      );
-      expect(explained, equals('[RichText:(:Hello (#FFFF0000:World)(:!))]'));
+    group('resets FIGURE margin', () {
+      const html = '<figure>Foo</figure>';
+
+      testWidgets('renders without value', (WidgetTester tester) async {
+        final e = await explain(tester, HtmlWidget(html, key: helper.hwKey));
+        expect(
+          e,
+          equals(
+            '[Padding:(0,40,0,40),child='
+            '[CssBlock:child=[RichText:(:Foo)]]'
+            ']',
+          ),
+        );
+      });
+
+      testWidgets('renders with value', (WidgetTester tester) async {
+        final explained = await explain(
+          tester,
+          HtmlWidget(
+            html,
+            key: helper.hwKey,
+            tags: {
+              'figure': BuildOp.v1(defaultStyles: (_) => {'margin': '0'})
+            },
+          ),
+        );
+        expect(explained, equals('[CssBlock:child=[RichText:(:Foo)]]'));
+      });
     });
   });
 


### PR DESCRIPTION
The goal is to deprecate custom {style,widget} builders and switch to an easier to understand customization approach. 