### PR TITLE
Update Chewie to the latest for support wakelock_plus

### DIFF
--- a/packages/fwfh_chewie/pubspec.yaml
+++ b/packages/fwfh_chewie/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.14.0 <4.0.0"
 
 dependencies:
-  chewie: ^1.0.0
+  chewie: ^1.7.0
   flutter:
     sdk: flutter
   flutter_widget_from_html_core: ">=0.8.0 <0.11.0"


### PR DESCRIPTION
Update chewie to support [wakelock_plus](https://pub.dev/packages/wakelock_plus)