### PR TITLE
Replace the deprecated `DecoderCallback` in tests

### DIFF
--- a/demo_app/pubspec.lock
+++ b/demo_app/pubspec.lock
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: archive
-      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      sha256: "49b1fad315e57ab0bbc15bcbb874e83116a1d78f77ebd500a4af6c9407d6b28e"
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.7"
+    version: "3.3.8"
   args:
     dependency: transitive
     description:

--- a/packages/core/test/tag_img_test.dart
+++ b/packages/core/test/tag_img_test.dart
@@ -429,7 +429,9 @@ class _TestImageProvider extends ImageProvider<Object> {
       SynchronousFuture<_TestImageProvider>(this);
 
   @override
-  ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) =>
+  // TODO: switch to use `loadImage` when our minimum Flutter version >= 3.10
+  // ignore: deprecated_member_use
+  ImageStreamCompleter loadBuffer(Object key, DecoderBufferCallback decode) =>
       streamCompleter;
 }
 

--- a/packages/core/test/tag_img_test.dart
+++ b/packages/core/test/tag_img_test.dart
@@ -429,9 +429,7 @@ class _TestImageProvider extends ImageProvider<Object> {
       SynchronousFuture<_TestImageProvider>(this);
 
   @override
-  // TODO: switch to use load buffer when ImageProvider does
-  // ignore: deprecated_member_use
-  ImageStreamCompleter load(Object key, DecoderCallback decode) =>
+  ImageStreamCompleter loadImage(Object key, ImageDecoderCallback decode) =>
       streamCompleter;
 }
 


### PR DESCRIPTION
We have to fix this to avoid failing tests in `Flutter@master`.