### PR TITLE
Fix audio_player throws exception when max value is 0

### DIFF
--- a/packages/fwfh_just_audio/lib/src/audio_player/audio_player.dart
+++ b/packages/fwfh_just_audio/lib/src/audio_player/audio_player.dart
@@ -231,7 +231,7 @@ class _PositionSlider extends StatelessWidget {
         builder: (_, duration) => StreamBuilder<Duration>(
           builder: (_, position) {
             final max = duration.data?.inMilliseconds.toDouble();
-            if (max == null) {
+            if (max == null || max == 0) {
               return widget0;
             }
 


### PR DESCRIPTION
# General:
Running on IOS simulator
Closes #980 
Closes #981 

# Describe problem:
980:
Due to Slider assert constructor, when max == 0 and value == 0, it throws
```
The following assertion was thrown building CupertinoSlider(value: 0.0, min: 0.0, max: 0.0, dependencies: [_InheritedCupertinoTheme], state: _CupertinoSliderState#e94ea):
'package:flutter/src/cupertino/slider.dart': Failed assertion: line 334 pos 15: 'value >= 0.0 && value <= 1.0': is not true.
```

981:
Same issue, only when back to home_page, the slider max && value is reset to 0, causing the same exception but in a different screen

🔔 This affects not just the Demo app, but anywhere which has the same html element.

# Changes:
- Add max == 0 check along with null check ( I see no difference in behavior after adding the 0 check )

# UI Evidence:

## Before:
https://github.com/daohoangson/flutter_widget_from_html/assets/48094980/dd7d0016-b563-40e4-8874-4d22ff909988

## After
https://github.com/daohoangson/flutter_widget_from_html/assets/48094980/8d8954fa-6ead-4a97-adb9-0f9e9c882361





