### PR TITLE
Feature add support text-shadow style

### DIFF
--- a/demo_app/lib/screens/home.dart
+++ b/demo_app/lib/screens/home.dart
@@ -11,6 +11,7 @@ import 'package:demo_app/screens/img.dart';
 import 'package:demo_app/screens/img_file.dart';
 import 'package:demo_app/screens/photo_view.dart';
 import 'package:demo_app/screens/smilie.dart';
+import 'package:demo_app/screens/text_shadow_screen.dart';
 import 'package:demo_app/screens/video.dart';
 import 'package:demo_app/screens/wordpress.dart';
 import 'package:demo_app/widgets/popup_menu.dart';
@@ -33,6 +34,7 @@ class HomeScreen extends StatelessWidget {
     'Photo View': () => const PhotoViewScreen(),
     'Smilie': () => const SmilieScreen(),
     'Wordpress': () => const WordpressScreen(),
+    'Text Shadow': () => const TextShadowScreen(),
   };
 
   const HomeScreen({super.key});

--- a/demo_app/lib/screens/text_shadow_screen.dart
+++ b/demo_app/lib/screens/text_shadow_screen.dart
@@ -86,7 +86,11 @@ class _TextShadowScreenState extends State<TextShadowScreen> {
                 style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
               ),
               const SizedBox(height: 8),
-              const HtmlWidget(_kHtml),
+              const Expanded(
+                child: SingleChildScrollView(
+                  child: HtmlWidget(_kHtml),
+                ),
+              ),
             ],
           ),
         ),

--- a/demo_app/lib/screens/text_shadow_screen.dart
+++ b/demo_app/lib/screens/text_shadow_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
+
+const _kHtml = '''
+  <h3>text-shadow: 1px 1px 2px #FC0;</h3>
+  <p style="text-shadow: 1px 1px 2px #FC0;">Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy called X ...</p>
+
+  <h3>text-shadow: #FC0 1px 0 10px;</h3>
+  <p style="text-shadow: #FC0 1px 0 10px;">Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy called X ...</p>
+
+  <h3>text-shadow: 5px 5px #558ABB;</h3>
+  <p style="text-shadow: 5px 5px #558ABB;">Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy called X ...</p>
+
+  <h3>text-shadow: red 2px 5px;</h3>
+  <p style="text-shadow: red 2px 5px;">Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy called X ...</p>
+
+  <h3>text-shadow: 5px 10px;</h3>
+  <p style="text-shadow: 5px 10px;">Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy called X ...</p>
+
+  <h3>text-shadow: 1px 1px 2px #558ABB, 0 0 1em #FC0, 0 0 0.2em #FC0;</h3>
+  <p style="text-shadow:  1px 1px 2px #558ABB, 0 0 1em #FC0, 0 0 0.2em #FC0;">Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy called X ...</p>
+''';
+
+class TextShadowScreen extends StatefulWidget {
+  const TextShadowScreen({super.key});
+
+  @override
+  State<TextShadowScreen> createState() => _TextShadowScreenState();
+}
+
+class _TextShadowScreenState extends State<TextShadowScreen> {
+  final ValueNotifier<String> _customShadowInput = ValueNotifier<String>('');
+  final TextEditingController _textEditingController = TextEditingController();
+
+  String _buildCustomShadowHtml(String customShadow) {
+    return '<p style="text-shadow: $customShadow; font-size: 16px">Custom text: Far out in the uncharted backwaters of the unfashionable end of the western spiral arm of the Galaxy ...</p>';
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _customShadowInput.value = _buildCustomShadowHtml('');
+    _textEditingController.addListener(() {
+      _customShadowInput.value = _buildCustomShadowHtml(
+        _textEditingController.text,
+      );
+    });
+  }
+
+  @override
+  void dispose() {
+    _textEditingController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Try custom shadow',
+                style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _textEditingController,
+                decoration: const InputDecoration(
+                  hintText: 'Custom shadow',
+                ),
+              ),
+              const SizedBox(height: 8),
+              ValueListenableBuilder<String>(
+                valueListenable: _customShadowInput,
+                builder: (context, newValue, child) {
+                  return HtmlWidget(newValue);
+                },
+              ),
+              const SizedBox(height: 32),
+              const Text(
+                'Example',
+                style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 8),
+              const HtmlWidget(_kHtml),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -1122,6 +1122,10 @@ class WidgetFactory extends WidgetFactoryResetter with AnchorWidgetFactory {
           tree.inherit(text_ops.whitespace, whitespace);
         }
         break;
+
+      case kCssTextShadow:
+        textShadowApply(tree, style);
+        break;
     }
 
     if (key.startsWith(kCssBackground)) {

--- a/packages/core/lib/src/internal/core_ops.dart
+++ b/packages/core/lib/src/internal/core_ops.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:csslib/visitor.dart' as css;
+import 'package:csslib/visitor.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart'
     show
@@ -14,6 +15,7 @@ import 'package:logging/logging.dart';
 import '../core_data.dart';
 import '../core_helpers.dart';
 import '../core_widget_factory.dart';
+import '../utils/list_utils.dart';
 import 'core_parser.dart';
 import 'margin_vertical.dart';
 import 'text_ops.dart' as text_ops;
@@ -31,6 +33,7 @@ part 'ops/style_padding.dart';
 part 'ops/style_sizing.dart';
 part 'ops/style_text_align.dart';
 part 'ops/style_text_decoration.dart';
+part 'ops/style_text_shadow.dart';
 part 'ops/style_vertical_align.dart';
 part 'ops/tag_a.dart';
 part 'ops/tag_br.dart';

--- a/packages/core/lib/src/internal/ops/style_text_shadow.dart
+++ b/packages/core/lib/src/internal/ops/style_text_shadow.dart
@@ -1,0 +1,120 @@
+part of '../core_ops.dart';
+
+const String kCssTextShadow = 'text-shadow';
+
+/// Refer https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow
+void textShadowApply(BuildTree tree, css.Declaration style) {
+  final styleExpression = style.expression as css.Expressions?;
+  final expressions = styleExpression?.expressions;
+
+  if (expressions?.isNotEmpty == true) {
+    tree.inherit(_textShadow, _extractToIndividualExpressions(expressions!));
+  }
+}
+
+/// This is to support multiple values separated by a comma
+/// 1px 1px 2px #558ABB, 0 0 1em #24A8BB, 0 0 0.2em #FC0;
+List<List<Expression>> _extractToIndividualExpressions(
+  List<Expression> expressions,
+) {
+  final List<List<Expression>> extractedList = [];
+
+  List<Expression> chunk = [];
+
+  for (final Expression exp in expressions) {
+    if (exp is OperatorComma) {
+      extractedList.add(chunk);
+      chunk = [];
+    } else {
+      chunk.add(exp);
+    }
+  }
+
+  if (chunk.isNotEmpty) {
+    extractedList.add(chunk);
+  }
+
+  return extractedList;
+}
+
+InheritedProperties _textShadow(
+  InheritedProperties resolving,
+  List<List<Expression>> expressions,
+) {
+  final List<Shadow> shadows = [];
+  final defaultColor =
+      resolving.parent?.get<TextStyle>()?.color ?? const Color(0xff000000);
+
+  for (final List<Expression> exp in expressions) {
+    final shadow = _parseExpressionToShadow(exp, defaultColor);
+    if (shadow != null) {
+      shadows.add(shadow);
+    }
+  }
+
+  return resolving.copyWith(
+    style: TextStyle(shadows: shadows),
+  );
+}
+
+///
+/// offset-x | offset-y | blur-radius | color
+/// text-shadow: 1px 1px 2px black;
+///
+/// color | offset-x | offset-y | blur-radius
+/// text-shadow: #fc0 1px 0 10px;
+///
+/// offset-x | offset-y | color
+/// text-shadow: 5px 5px #558abb;
+///
+/// color | offset-x | offset-y
+/// text-shadow: white 2px 5px
+///
+/// offset-x | offset-y
+/// text-shadow: 5px 10px
+///
+Shadow? _parseExpressionToShadow(
+  List<Expression> expressions,
+  Color defaultColor,
+) {
+  Color? color;
+  double? offsetX;
+  double? offsetY;
+  double? blurRadius;
+
+  if (expressions.length < 2 || expressions.length > 4) {
+    return null;
+  }
+
+  // Parse color
+  // Color is ALWAYS either the first or the last index
+  int colorOffsetIndex = 0;
+  color = tryParseColor(expressions.last);
+
+  if (color == null) {
+    color = tryParseColor(expressions.first);
+    colorOffsetIndex = 1;
+  }
+
+  if (color == null && expressions.length > 3) {
+    return null;
+  }
+  // Parse size + blur radius
+  // According to the docs, the valid ordering must always be
+  // offset-x , off-set-y , blur-radius (optional)
+  offsetX = tryParseCssLength(
+    expressions.safeGetAt(0 + colorOffsetIndex),
+  )?.number;
+  offsetY = tryParseCssLength(
+    expressions.safeGetAt(1 + colorOffsetIndex),
+  )?.number;
+  blurRadius = tryParseCssLength(
+    expressions.safeGetAt(2 + colorOffsetIndex),
+  )?.number;
+
+  return Shadow(
+    color: color ?? defaultColor,
+    offset: Offset(offsetX ?? 0.0, offsetY ?? 0.0),
+    blurRadius: blurRadius ?? 0.0,
+  );
+}

--- a/packages/core/lib/src/internal/ops/style_text_shadow.dart
+++ b/packages/core/lib/src/internal/ops/style_text_shadow.dart
@@ -89,11 +89,14 @@ Shadow? _parseExpressionToShadow(
   // Parse color
   // Color is ALWAYS either the first or the last index
   int colorOffsetIndex = 0;
+
   color = tryParseColor(expressions.last);
 
   if (color == null) {
     color = tryParseColor(expressions.first);
-    colorOffsetIndex = 1;
+    if (color != null) {
+      colorOffsetIndex = 1;
+    }
   }
 
   if (color == null && expressions.length > 3) {

--- a/packages/core/lib/src/internal/parser/length.dart
+++ b/packages/core/lib/src/internal/parser/length.dart
@@ -4,7 +4,7 @@ CssLength? tryParseCssLength(css.Expression? expression) {
   if (expression == null) {
     return null;
   }
-  
+
   if (expression is css.EmTerm) {
     return CssLength((expression.value as num).toDouble(), CssLengthUnit.em);
   } else if (expression is css.LengthTerm) {

--- a/packages/core/lib/src/internal/parser/length.dart
+++ b/packages/core/lib/src/internal/parser/length.dart
@@ -1,6 +1,10 @@
 part of '../core_parser.dart';
 
-CssLength? tryParseCssLength(css.Expression expression) {
+CssLength? tryParseCssLength(css.Expression? expression) {
+  if (expression == null) {
+    return null;
+  }
+  
   if (expression is css.EmTerm) {
     return CssLength((expression.value as num).toDouble(), CssLengthUnit.em);
   } else if (expression is css.LengthTerm) {

--- a/packages/core/lib/src/utils/list_utils.dart
+++ b/packages/core/lib/src/utils/list_utils.dart
@@ -1,0 +1,9 @@
+extension ListExt<T> on List<T> {
+  T? safeGetAt(int index) {
+    if (index < 0 || index > length - 1) {
+      return null;
+    }
+
+    return this[index];
+  }
+}

--- a/packages/core/test/_.dart
+++ b/packages/core/test/_.dart
@@ -512,6 +512,7 @@ class Explainer {
 
     s += _textStyleFontStyle(style);
     s += _textStyleFontWeight(style);
+    s += _textStyleShadow(style);
 
     return s;
   }
@@ -566,6 +567,22 @@ class Explainer {
       return '+b';
     }
     return '+w${FontWeight.values.indexOf(fontWeight)}';
+  }
+
+  String _textStyleShadow(TextStyle style) {
+    final shadows = style.shadows;
+    if (shadows?.isNotEmpty != true) {
+      return '';
+    }
+
+    String s = '';
+
+    shadows?.forEach((element) {
+      s +=
+          'Shadow=[color=${_color(element.color)},offset=${element.offset},blurRadius=${element.blurRadius}]';
+    });
+
+    return s;
   }
 
   List<String> _flex(Flex flex) {

--- a/packages/core/test/style_text_shadow_test.dart
+++ b/packages/core/test/style_text_shadow_test.dart
@@ -96,4 +96,52 @@ void main() {
       ),
     );
   });
+
+  testWidgets('text-shadow no shadow on missing offset',
+      (WidgetTester tester) async {
+    const html = '<p style="text-shadow: 1px #558ABB;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals('[CssBlock:child=[RichText:(:Anime)]]'),
+    );
+  });
+
+  testWidgets('text-shadow no shadow on missing offset color first',
+      (WidgetTester tester) async {
+    const html = '<p style="text-shadow: #558ABB 2px;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals('[CssBlock:child=[RichText:(:Anime)]]'),
+    );
+  });
+
+  testWidgets('text-shadow no shadow on data < 1', (WidgetTester tester) async {
+    const html = '<p style="text-shadow: 5px;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals('[CssBlock:child=[RichText:(:Anime)]]'),
+    );
+  });
+
+  testWidgets('text-shadow no shadow on data > 4', (WidgetTester tester) async {
+    const html = '<p style="text-shadow: #558ABB 2px 5px 6px 4px;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals('[CssBlock:child=[RichText:(:Anime)]]'),
+    );
+  });
+
+  testWidgets('text-shadow no shadow only has color',
+      (WidgetTester tester) async {
+    const html = '<p style="text-shadow: #558ABB;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals('[CssBlock:child=[RichText:(:Anime)]]'),
+    );
+  });
 }

--- a/packages/core/test/style_text_shadow_test.dart
+++ b/packages/core/test/style_text_shadow_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '_.dart';
+
+void main() {
+  testWidgets('text-shadow x y blur color', (WidgetTester tester) async {
+    const html = '<p style="text-shadow: 1px 1px 2px #FC0;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals(
+        '[CssBlock:child=[RichText:('
+        'Shadow=[color=#FFFFCC00,offset=Offset(1.0, 1.0),blurRadius=2.0]'
+        ':Anime)]]',
+      ),
+    );
+  });
+
+  testWidgets('text-shadow color x y blur', (WidgetTester tester) async {
+    const html = '<p style="text-shadow: #FC0 1px 0 10px;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals(
+        '[CssBlock:child=[RichText:('
+        'Shadow=[color=#FFFFCC00,offset=Offset(1.0, 0.0),blurRadius=10.0]'
+        ':Anime)]]',
+      ),
+    );
+  });
+
+  testWidgets('text-shadow x y color', (WidgetTester tester) async {
+    const html = '<p style="text-shadow: 5px 5px #558ABB;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals(
+        '[CssBlock:child=[RichText:('
+        'Shadow=[color=#FF558ABB,offset=Offset(5.0, 5.0),blurRadius=0.0]'
+        ':Anime)]]',
+      ),
+    );
+  });
+
+  testWidgets('text-shadow red x y', (WidgetTester tester) async {
+    const html = '<p style="text-shadow: red 2px 5px;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals(
+        '[CssBlock:child=[RichText:('
+        'Shadow=[color=#FFFF0000,offset=Offset(2.0, 5.0),blurRadius=0.0]'
+        ':Anime)]]',
+      ),
+    );
+  });
+
+  testWidgets('text-shadow x y', (WidgetTester tester) async {
+    const html = '<p style="text-shadow: 5px 10px;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals(
+        '[CssBlock:child=[RichText:('
+        'Shadow=[color=#FF001234,offset=Offset(5.0, 10.0),blurRadius=0.0]'
+        ':Anime)]]',
+      ),
+    );
+  });
+
+  testWidgets('text-shadow x y color', (WidgetTester tester) async {
+    const html = '<p style="text-shadow: 1px 1px 2px #558ABB;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals(
+        '[CssBlock:child=[RichText:('
+        'Shadow=[color=#FF558ABB,offset=Offset(1.0, 1.0),blurRadius=2.0]'
+        ':Anime)]]',
+      ),
+    );
+  });
+}

--- a/packages/core/test/style_text_shadow_test.dart
+++ b/packages/core/test/style_text_shadow_test.dart
@@ -80,4 +80,20 @@ void main() {
       ),
     );
   });
+
+  testWidgets('text-shadow multiple shadows', (WidgetTester tester) async {
+    const html =
+        '<p style="text-shadow: 1px 1px 2px #558ABB, 0 0 1em #FC0, 0 0 0.2em #FC0;">Anime</p>';
+    final explained = await explain(tester, html);
+    expect(
+      explained,
+      equals(
+        '[CssBlock:child=[RichText:('
+        'Shadow=[color=#FF558ABB,offset=Offset(1.0, 1.0),blurRadius=2.0]'
+        'Shadow=[color=#FFFFCC00,offset=Offset(0.0, 0.0),blurRadius=1.0]'
+        'Shadow=[color=#FFFFCC00,offset=Offset(0.0, 0.0),blurRadius=0.2]'
+        ':Anime)]]',
+      ),
+    );
+  });
 }


### PR DESCRIPTION
Add support for https://github.com/daohoangson/flutter_widget_from_html/issues/586

The structure is kinda new to me, so please take a look and feel free to drop comments, i'll try to address them.
I follow the examples + rules here https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow

# Changes:
- Add basic support for text-shadow
- Add Text Shadow showcase in Demo App

