### PR TITLE
Set IFRAME width & height to conform to platform view constraints

### DIFF
--- a/packages/fwfh_webview/lib/src/web_view/js_interop.dart
+++ b/packages/fwfh_webview/lib/src/web_view/js_interop.dart
@@ -20,6 +20,11 @@ class WebViewState extends State<WebView> {
       _iframeElement.allow = 'autoplay';
     }
 
+    // https://docs.flutter.dev/release/breaking-changes/platform-views-using-html-slots-web
+    _iframeElement.style
+      ..height = '100%'
+      ..width = '100%';
+
     final viewType = '$this#$hashCode';
 
     platformViewRegistry.registerViewFactory(viewType, (_) => _iframeElement);


### PR DESCRIPTION
See https://docs.flutter.dev/release/breaking-changes/platform-views-using-html-slots-web

Related to #1245