### PR TITLE
Fix extra space with consecutive <br> tags

### DIFF
--- a/packages/core/lib/src/internal/ops/tag_br.dart
+++ b/packages/core/lib/src/internal/ops/tag_br.dart
@@ -25,7 +25,15 @@ class TagBrBit extends BuildBit {
   BuildBit copyWith({BuildTree? parent}) => TagBrBit(parent ?? this.parent);
 
   @override
-  void flatten(Flattened f) => f.write(text: '\n');
+  void flatten(Flattened f) {
+    final previousBit = parent.bits.isNotEmpty ? parent.bits.last : null;
+    if (previousBit is TagBrBit) {
+      // Do not add extra space if the previous bit is also a <br> tag
+      return;
+    }
+
+    f.write(text: '\n');
+  }
 
   @override
   String toString() => '<BR />';


### PR DESCRIPTION
Related to #1280

Implements improved handling of consecutive `<br>` tags in `HtmlWidget` to prevent extra space between images.
- Modifies the `flatten` method in the `TagBrBit` class to check if the previous bit is also a `<br>` tag. If so, it avoids adding extra space by not writing a newline character. This change ensures that consecutive `<br>` tags between images do not result in additional space, aligning the rendered output more closely with expected web standards. 
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/daohoangson/flutter_widget_from_html/issues/1280?shareId=061a1f2a-b221-4927-bbd8-fadf3bced196).