### PR TITLE
Fix invalid CSS handling in HtmlWidget

### DIFF
--- a/packages/core/lib/src/core_helpers.dart
+++ b/packages/core/lib/src/core_helpers.dart
@@ -3,6 +3,8 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
 import 'package:html/dom.dart' as dom;
+import 'package:csslib/parser.dart' as css_parser;
+import 'package:csslib/visitor.dart' as css_visitor;
 
 import 'core_data.dart';
 import 'core_html_widget.dart';
@@ -216,4 +218,16 @@ int? tryParseIntFromMap(Map<dynamic, String> map, String key) {
   }
 
   return int.tryParse(value);
+}
+
+/// Checks if a CSS string is valid.
+bool isValidCss(String cssString) {
+  try {
+    final errors = <css_parser.Message>[];
+    final parser = css_parser.Parser();
+    parser.parse(cssString, errors: errors);
+    return errors.isEmpty;
+  } catch (e) {
+    return false;
+  }
 }

--- a/packages/core/test/src/core_helpers_test.dart
+++ b/packages/core/test/src/core_helpers_test.dart
@@ -25,4 +25,16 @@ void main() {
       });
     });
   });
+
+  group('isValidCss', () {
+    test('returns true for valid CSS', () {
+      final cssString = 'body { background-color: red; }';
+      expect(isValidCss(cssString), isTrue);
+    });
+
+    test('returns false for invalid CSS', () {
+      final cssString = 'body { background-color: red; # }';
+      expect(isValidCss(cssString), isFalse);
+    });
+  });
 }

--- a/packages/enhanced/README.md
+++ b/packages/enhanced/README.md
@@ -100,6 +100,15 @@ HtmlWidget(
 
   // set the default styling for text
   textStyle: TextStyle(fontSize: 14),
+
+  // handle invalid HTML/CSS
+  onErrorBuilder: (context, element, error) {
+    if (error is css_parser.Message) {
+      // Ignore invalid CSS errors
+      return null;
+    }
+    return const Text('Error parsing the message!');
+  },
 ),
 ```
 

--- a/packages/enhanced/lib/src/html_widget.dart
+++ b/packages/enhanced/lib/src/html_widget.dart
@@ -31,4 +31,17 @@ class HtmlWidget extends core.HtmlWidget {
   }) : super(factoryBuilder: factoryBuilder ?? _getEnhancedWf);
 
   static WidgetFactory _getEnhancedWf() => WidgetFactory();
+
+  @override
+  Widget? onErrorBuilder(
+    BuildContext context,
+    dom.Element element,
+    dynamic error,
+  ) {
+    if (error is css_parser.Message) {
+      // Ignore invalid CSS errors
+      return null;
+    }
+    return super.onErrorBuilder(context, element, error);
+  }
 }


### PR DESCRIPTION
Related to #1287

Address the issue of invalid CSS causing errors in `HtmlWidget`.

* **Add `isValidCss` function**: Add a new function `isValidCss` in `packages/core/lib/src/core_helpers.dart` to check if a CSS string is valid.
* **Update `HtmlWidget`**: Modify `HtmlWidget` in `packages/enhanced/lib/src/html_widget.dart` to ignore invalid CSS errors in the `onErrorBuilder` callback.
* **Add unit tests**: Add unit tests for the `isValidCss` function in `packages/core/test/src/core_helpers_test.dart`.
* **Update documentation**: Update `packages/enhanced/README.md` to include examples on handling invalid HTML/CSS in `HtmlWidget`.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/daohoangson/flutter_widget_from_html/issues/1287?shareId=5806cad3-e912-4a85-8503-69db870d614d).