### PR TITLE
Added: Support for AUDIO SOURCE tags

### DIFF
--- a/packages/fwfh_just_audio/lib/src/internal/tag_audio.dart
+++ b/packages/fwfh_just_audio/lib/src/internal/tag_audio.dart
@@ -2,6 +2,7 @@
 // ignore_for_file: deprecated_member_use
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 
 import '../just_audio_factory.dart';
@@ -14,6 +15,7 @@ const kAttributeAudioPreloadNone = 'none';
 const kAttributeAudioSrc = 'src';
 
 const kTagAudio = 'audio';
+const kTagAudioSource = 'source';
 
 class TagAudio {
   final JustAudioFactory wf;
@@ -21,34 +23,69 @@ class TagAudio {
   TagAudio(this.wf);
 
   BuildOp get buildOp => BuildOp(
-        // TODO: set debugLabel when our minimum core version >= 1.0
-        onWidgets: (meta, widgets) {
+        debugLabel: kTagAudio,
+        onRenderBlock: (tree, placeholder) {
           if (defaultTargetPlatform != TargetPlatform.android &&
               defaultTargetPlatform != TargetPlatform.iOS &&
               defaultTargetPlatform != TargetPlatform.macOS &&
               !kIsWeb) {
             // these are the just_audio's supported platforms
             // https://pub.dev/packages/just_audio/versions/0.9.5
-            return widgets;
+            return placeholder;
           }
 
-          final attrs = meta.element.attributes;
+          final attrs = tree.element.attributes;
+          final url = wf.urlFull(attrs[kAttributeAudioSrc] ?? '');
+          if (url != null) {
+            tree.audioData.urls.add(url);
+          }
+
+          return _buildPlayer(tree) ?? placeholder;
+        },
+        onVisitChild: (tree, subTree) {
+          final e = subTree.element;
+          if (e.localName != kTagAudioSource) {
+            return;
+          }
+          if (e.parent != tree.element) {
+            return;
+          }
+
+          final attrs = e.attributes;
           final url = wf.urlFull(attrs[kAttributeAudioSrc] ?? '');
           if (url == null) {
-            return widgets;
+            return;
           }
 
-          final built = wf.buildAudioPlayer(
-            meta,
-            url,
-            autoplay: attrs.containsKey(kAttributeAudioAutoplay),
-            loop: attrs.containsKey(kAttributeAudioLoop),
-            muted: attrs.containsKey(kAttributeAudioMuted),
-            preload: attrs.containsKey(kAttributeAudioPreload) &&
-                attrs[kAttributeAudioPreload] != kAttributeAudioPreloadNone,
-          );
-
-          return listOrNull(built) ?? widgets;
+          tree.audioData.urls.add(url);
         },
       );
+
+  Widget? _buildPlayer(BuildTree tree) {
+    final sourceUrls = tree.audioData.urls;
+    if (sourceUrls.isEmpty) {
+      return null;
+    }
+
+    final attrs = tree.element.attributes;
+    return wf.buildAudioPlayer(
+      tree,
+      sourceUrls.first,
+      autoplay: attrs.containsKey(kAttributeAudioAutoplay),
+      loop: attrs.containsKey(kAttributeAudioLoop),
+      muted: attrs.containsKey(kAttributeAudioMuted),
+      preload: attrs.containsKey(kAttributeAudioPreload) &&
+          attrs[kAttributeAudioPreload] != kAttributeAudioPreloadNone,
+    );
+  }
+}
+
+extension on BuildTree {
+  _TagAudioData get audioData =>
+      getNonInherited<_TagAudioData>() ?? setNonInherited(_TagAudioData());
+}
+
+@immutable
+class _TagAudioData {
+  final urls = <String>[];
 }

--- a/packages/fwfh_just_audio/lib/src/just_audio_factory.dart
+++ b/packages/fwfh_just_audio/lib/src/just_audio_factory.dart
@@ -13,7 +13,7 @@ mixin JustAudioFactory on WidgetFactory {
 
   /// Builds [AudioPlayer].
   Widget? buildAudioPlayer(
-    BuildMetadata meta,
+    BuildTree tree,
     String url, {
     required bool autoplay,
     required bool loop,
@@ -29,13 +29,12 @@ mixin JustAudioFactory on WidgetFactory {
       );
 
   @override
-  void parse(BuildMetadata meta) {
-    switch (meta.element.localName) {
+  void parse(BuildTree tree) {
+    switch (tree.element.localName) {
       case kTagAudio:
-        _tagAudio ??= TagAudio(this).buildOp;
-        meta.register(_tagAudio!);
+        tree.register(_tagAudio ??= TagAudio(this).buildOp);
         break;
     }
-    return super.parse(meta);
+    return super.parse(tree);
   }
 }

--- a/packages/fwfh_just_audio/pubspec.yaml
+++ b/packages/fwfh_just_audio/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fwfh_just_audio
-version: 0.15.1
+version: 0.15.2
 description: WidgetFactory extension to render AUDIO with the just_audio plugin.
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 


### PR DESCRIPTION
These changes add support for `AUDIO` `SOURCE` elements while supporting the `src` attribute added directly in the `AUDIO` element if no `SOURCE` children are provided.