### PR TITLE
Fix iOS code signing issue during integration test

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -63,7 +63,7 @@ jobs:
             --use-orchestrator
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-15-arm64
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Flutter

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -63,7 +63,7 @@ jobs:
             --use-orchestrator
 
   ios:
-    runs-on: macos-15-arm64
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Setup Flutter

--- a/demo_app/ios/fastlane/Fastfile
+++ b/demo_app/ios/fastlane/Fastfile
@@ -34,6 +34,8 @@ platform :ios do
       readonly: true
     )
 
+    sh('security default-keychain')
+
     sh('cd ../.. && patrol build ios --release --verbose --target integration_test/auto_resize_test.dart')
   end
 end

--- a/demo_app/ios/fastlane/Fastfile
+++ b/demo_app/ios/fastlane/Fastfile
@@ -20,21 +20,24 @@ platform :ios do
   end
 
   lane :patrol_build do
+    sh('security default-keychain')
+
     setup_ci
+    sh('security default-keychain')
 
     match(
       app_identifier: ["dev.fwfh.demoApp", "dev.fwfh.demoApp.RunnerTests"],
       type: 'appstore',
       readonly: true
     )
+    sh('security find-identity -v -p codesigning')
 
     match(
       app_identifier: ["dev.fwfh.demoApp.RunnerUITests.xctrunner"],
       type: 'development',
       readonly: true
     )
-
-    sh('security default-keychain')
+    sh('security find-identity -v -p codesigning')
 
     sh('cd ../.. && patrol build ios --release --verbose --target integration_test/auto_resize_test.dart')
   end

--- a/demo_app/ios/fastlane/Fastfile
+++ b/demo_app/ios/fastlane/Fastfile
@@ -20,6 +20,8 @@ platform :ios do
   end
 
   lane :patrol_build do
+    setup_ci
+
     match(
       app_identifier: ["dev.fwfh.demoApp", "dev.fwfh.demoApp.RunnerTests"],
       type: 'appstore',

--- a/demo_app/ios/fastlane/Fastfile
+++ b/demo_app/ios/fastlane/Fastfile
@@ -20,8 +20,6 @@ platform :ios do
   end
 
   lane :patrol_build do
-    setup_ci
-
     match(
       app_identifier: ["dev.fwfh.demoApp", "dev.fwfh.demoApp.RunnerTests"],
       type: 'appstore',


### PR DESCRIPTION
Fastlane match created a temporary keychain successfully. Imported certificates (ours and Apple's) and private key OK. But somehow the code sign is not valid. Happened on both local env & GitHub Actions...

On local env, it works correctly with the login keychain (the default one).

So...