### PR TITLE
fix: text-align center not working on li elements

### DIFF
--- a/packages/core/lib/src/internal/ops/style_text_align.dart
+++ b/packages/core/lib/src/internal/ops/style_text_align.dart
@@ -47,6 +47,13 @@ extension StyleTextAlign on WidgetFactory {
       return placeholder.wrapWith(_center);
     }
 
+    // Only wrap block-level elements with CssBlock to force full width,
+    // skip inline-block which should keep its own sizing
+    final display = tree.getStyle(kCssDisplay)?.term;
+    if (display == kCssDisplayInlineBlock) {
+      return placeholder;
+    }
+
     switch (term) {
       case kCssTextAlignCenter:
       case kCssTextAlignEnd:

--- a/packages/core/lib/src/internal/ops/style_text_align.dart
+++ b/packages/core/lib/src/internal/ops/style_text_align.dart
@@ -23,6 +23,9 @@ extension StyleTextAlign on WidgetFactory {
         priority: Early.cssTextAlign,
       );
 
+  static Widget _block(BuildContext context, Widget child) =>
+      CssBlock(child: child);
+
   static Widget _center(BuildContext context, Widget child) =>
       Center(heightFactor: 1.0, child: child);
 
@@ -35,12 +38,25 @@ extension StyleTextAlign on WidgetFactory {
   }
 
   static Widget _onRenderBlock(BuildTree tree, WidgetPlaceholder placeholder) {
-    if (placeholder.isEmpty ||
-        tree.textAlignData.term != kCssTextAlignWebkitCenter) {
+    if (placeholder.isEmpty) {
       return placeholder;
     }
 
-    return placeholder.wrapWith(_center);
+    final term = tree.textAlignData.term;
+    if (term == kCssTextAlignWebkitCenter) {
+      return placeholder.wrapWith(_center);
+    }
+
+    switch (term) {
+      case kCssTextAlignCenter:
+      case kCssTextAlignEnd:
+      case kCssTextAlignJustify:
+      case kCssTextAlignMozCenter:
+      case kCssTextAlignRight:
+        return placeholder.wrapWith(_block);
+      default:
+        return placeholder;
+    }
   }
 
   static InheritedProperties _textAlign(

--- a/packages/core/test/style_text_align_test.dart
+++ b/packages/core/test/style_text_align_test.dart
@@ -129,19 +129,34 @@ void main() {
     testWidgets('renders center', (WidgetTester tester) async {
       const html = '<div style="text-align: center"><div>_X_</div></div>';
       final e = await explain(tester, html);
-      expect(e, equals('[CssBlock:child=[RichText:align=center,(:_X_)]]'));
+      expect(
+        e,
+        equals(
+          '[CssBlock:child=[CssBlock:child=[RichText:align=center,(:_X_)]]]',
+        ),
+      );
     });
 
     testWidgets('renders end', (WidgetTester tester) async {
       const html = '<div style="text-align: end"><div>__X</div></div>';
       final e = await explain(tester, html);
-      expect(e, equals('[CssBlock:child=[RichText:align=end,(:__X)]]'));
+      expect(
+        e,
+        equals(
+          '[CssBlock:child=[CssBlock:child=[RichText:align=end,(:__X)]]]',
+        ),
+      );
     });
 
     testWidgets('renders justify', (WidgetTester tester) async {
       const html = '<div style="text-align: justify"><div>X_X_X</div></div>';
       final e = await explain(tester, html);
-      expect(e, equals('[CssBlock:child=[RichText:align=justify,(:X_X_X)]]'));
+      expect(
+        e,
+        equals(
+          '[CssBlock:child=[CssBlock:child=[RichText:align=justify,(:X_X_X)]]]',
+        ),
+      );
     });
 
     testWidgets('renders left', (WidgetTester tester) async {
@@ -153,7 +168,12 @@ void main() {
     testWidgets('renders right', (WidgetTester tester) async {
       const html = '<div style="text-align: right"><div>__X</div></div>';
       final e = await explain(tester, html);
-      expect(e, equals('[CssBlock:child=[RichText:align=right,(:__X)]]'));
+      expect(
+        e,
+        equals(
+          '[CssBlock:child=[CssBlock:child=[RichText:align=right,(:__X)]]]',
+        ),
+      );
     });
 
     testWidgets('renders start', (WidgetTester tester) async {

--- a/packages/core/test/tag_li_test.dart
+++ b/packages/core/test/tag_li_test.dart
@@ -677,6 +677,24 @@ Future<void> main() async {
         expect(explained, contains('[Padding:(0,0,0,99),child='));
       });
     });
+
+    group('text-align', () {
+      testWidgets('renders center on li', (WidgetTester tester) async {
+        const html = '<ol>'
+            '<li style="text-align: center;">Foo</li>'
+            '</ol>';
+        final explained = await explain(tester, html);
+        expect(explained, contains('[RichText:align=center,(:Foo)]'));
+      });
+
+      testWidgets('renders center on ol', (WidgetTester tester) async {
+        const html = '<ol style="text-align: center;">'
+            '<li>Foo</li>'
+            '</ol>';
+        final explained = await explain(tester, html);
+        expect(explained, contains('[RichText:align=center,(:Foo)]'));
+      });
+    });
   });
 
   group('error handling', () {
@@ -972,6 +990,7 @@ Future<void> main() async {
           list: urls,
         ),
       );
+
       expect(await tapText(tester, 'Tap me'), equals(1));
 
       await tester.pumpAndSettle();

--- a/packages/core/test/tag_table_test.dart
+++ b/packages/core/test/tag_table_test.dart
@@ -27,7 +27,7 @@ Future<void> main() async {
         explained,
         equals(
           '[SingleChildScrollView:child=[HtmlTable:children='
-          '[HtmlTableCaption:child=[RichText:align=center,(:Caption)]],'
+          '[HtmlTableCaption:child=[CssBlock:child=[RichText:align=center,(:Caption)]]],'
           '${_padding('[RichText:(+b:Header 1)]')},'
           '${_padding('[RichText:(+b:Header 2)]')},'
           '${_richtext('Value 1')},'
@@ -620,7 +620,7 @@ Future<void> main() async {
       explained,
       equals(
         '[SingleChildScrollView:child=[HtmlTable:children='
-        '[HtmlTableCaption:child=[RichText:align=center,(:Caption)]],'
+        '[HtmlTableCaption:child=[CssBlock:child=[RichText:align=center,(:Caption)]]],'
         '[HtmlTableCell:child=[CssBlock:child=[RichText:(+b:Header 1)]]],'
         '[HtmlTableCell:child=[CssBlock:child=[RichText:(+b:Header 2)]]],'
         '[HtmlTableCell:child=[CssBlock:child=[RichText:(:Value 1)]]],'


### PR DESCRIPTION
Tighten child width constraints in HtmlListItem to fill available width, matching browser behavior where li is a block element. This ensures text-align: center has visible effect on list item content.

Related to #1485