### PR TITLE
fix: ignore tight ListView min width for auto table sizing

### DIFF
--- a/packages/core/lib/src/internal/ops/tag_table.dart
+++ b/packages/core/lib/src/internal/ops/tag_table.dart
@@ -86,6 +86,7 @@ class TagTable {
     final layoutBuilder = HtmlLayoutBuilder(
       builder: (context, bc) {
         final resolved = tableTree.inheritanceResolvers.resolve(context);
+        final minWidth = _getMinWidthHint(tableTree, resolved, bc);
         Widget built = ValignBaselineContainer(
           child: HtmlTable(
             border: border.getBorder(resolved),
@@ -104,7 +105,7 @@ class TagTable {
         // provide hints to size the columns properly
         built = CssSizingHint(
           maxWidth: bc.maxWidth,
-          minWidth: bc.minWidth,
+          minWidth: minWidth,
           child: built,
         );
 
@@ -117,6 +118,27 @@ class TagTable {
     );
 
     return WidgetPlaceholder(debugLabel: kTagTable, child: layoutBuilder);
+  }
+
+  double _getMinWidthHint(
+    BuildTree tableTree,
+    InheritedProperties resolved,
+    BoxConstraints bc,
+  ) {
+    final input = tableTree.sizingInput;
+    final widths = [
+      input?.preferredWidth,
+      input?.minWidth,
+    ].map((v) => v?.getSizing(resolved)?.clamp(0.0, bc.maxWidth));
+
+    var minWidth = .0;
+    for (final width in widths) {
+      if (width != null && width.isFinite) {
+        minWidth = max(minWidth, width);
+      }
+    }
+
+    return minWidth;
   }
 
   void _prepareHtmlTableCaptionBuilders(_TagTableData data) {

--- a/packages/core/test/tag_table_test.dart
+++ b/packages/core/test/tag_table_test.dart
@@ -65,6 +65,46 @@ Future<void> main() async {
       // `HtmlTable` should not be put inside another one
       expect(explained, isNot(contains('SingleChildScrollView')));
     });
+
+    group('RenderMode.listView', () {
+      const windowSize = 100.0;
+
+      testWidgets('does not stretch auto width table', (tester) async {
+        tester.setWindowSize(const Size(windowSize, windowSize));
+
+        await explain(
+          tester,
+          null,
+          hw: HtmlWidget(
+            '<table><tr><td>Foo</td></tr></table>',
+            key: helper.hwKey,
+            renderMode: RenderMode.listView,
+          ),
+          useExplainer: false,
+        );
+
+        final table = tester.renderObject<RenderBox>(find.byType(HtmlTable));
+        expect(table.size.width, lessThan(windowSize));
+      });
+
+      testWidgets('stretches width 100 percent table', (tester) async {
+        tester.setWindowSize(const Size(windowSize, windowSize));
+
+        await explain(
+          tester,
+          null,
+          hw: HtmlWidget(
+            '<table style="width: 100%"><tr><td>Foo</td></tr></table>',
+            key: helper.hwKey,
+            renderMode: RenderMode.listView,
+          ),
+          useExplainer: false,
+        );
+
+        final table = tester.renderObject<RenderBox>(find.byType(HtmlTable));
+        expect(table.size.width, equals(windowSize));
+      });
+    });
   });
 
   group('rtl', () {


### PR DESCRIPTION
Fixes table sizing in `RenderMode.listView` so auto-width tables no longer stretch to the full viewport width just because `ListView` gives its children tight cross-axis constraints.

The table layout now derives its `minWidth` hint only from explicit table sizing, such as width or min-width, instead of copying `BoxConstraints.minWidth` from the parent layout.

Related #1595