### PR TITLE
fix(fwfh_cached_network_image): admit cached_network_image 4.0.0

### DIFF
--- a/packages/fwfh_cached_network_image/pubspec.yaml
+++ b/packages/fwfh_cached_network_image/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  cached_network_image: ^3.0.0
+  cached_network_image: ">=3.0.0 <5.0.0"
   flutter:
     sdk: flutter
   flutter_cache_manager: ^3.0.0


### PR DESCRIPTION
Related to #1620.

`cached_network_image` 4.0.0 raises its own SDK floor to Dart `^3.12.0` /
Flutter `>=3.44.0`. `fwfh_cached_network_image` pinned `^3.0.0`, so any
app pulling in 4.0.0 hit a version-solve conflict.

This widens the constraint to `>=3.0.0 <5.0.0` instead of bumping the pin
outright, so pub can pick 4.0.0 on newer toolchains while apps still on
an older Flutter/Dart keep resolving to the 3.x line. The public
`CachedNetworkImage` surface this package actually uses (`cacheManager`,
`errorWidget`, `fit`, `imageUrl`, `progressIndicatorBuilder`) is untouched
by 4.0.0 per its changelog, so no source changes were needed.