### PR TITLE
Fix latest lint preset findings

### DIFF
--- a/demo_app/test/flutter_test_config.dart
+++ b/demo_app/test/flutter_test_config.dart
@@ -4,5 +4,5 @@ import 'package:golden_toolkit/golden_toolkit.dart';
 
 Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   await loadAppFonts();
-  return testMain();
+  await testMain();
 }

--- a/packages/core/lib/src/core_html_widget.dart
+++ b/packages/core/lib/src/core_html_widget.dart
@@ -225,7 +225,7 @@ class HtmlWidgetState extends State<HtmlWidget> {
 
   Future<Widget> _buildAsync() async {
     if (widget.html.isEmpty) {
-      return Future.sync(() => _sliverOrWidget0);
+      return await Future.sync(() => _sliverOrWidget0);
     }
 
     final domNodes = await compute(_parseHtml, widget.html);

--- a/packages/core/lib/src/core_widget_factory.dart
+++ b/packages/core/lib/src/core_widget_factory.dart
@@ -635,7 +635,7 @@ class WidgetFactory extends WidgetFactoryResetter with AnchorWidgetFactory {
   /// Returns `true` if there is a callback and it has handled the tap.
   Future<bool> onTapCallback(String url) async {
     final callback = _widget?.onTapUrl;
-    return callback != null ? callback(url) : false;
+    return callback != null && await callback(url);
   }
 
   /// Handles user tapping a link.

--- a/packages/core/test/_.dart
+++ b/packages/core/test/_.dart
@@ -75,7 +75,7 @@ Future<String> explain(
     ),
   );
 
-  return explainWithoutPumping(
+  return await explainWithoutPumping(
     explainer: explainer,
     key: key,
     useExplainer: useExplainer,
@@ -780,32 +780,32 @@ class Explainer {
 
     if (widget is MultiChildRenderObjectWidget) {
       final dynamicWidget = widget as dynamic;
-      switch (widget.runtimeType.toString()) {
-        case 'HtmlFlex':
-          attr.add(
-            // TODO: remove ignore when our minimum core version >= 1.0
-            // ignore: avoid_dynamic_calls
-            'crossAxisAlignment=${dynamicWidget.crossAxisAlignment}'
-                .replaceAll('CrossAxisAlignment.', ''),
-          );
-          attr.add(
-            // TODO: remove ignore when our minimum core version >= 1.0
-            // ignore: avoid_dynamic_calls
-            'direction=${dynamicWidget.direction}'.replaceAll('Axis.', ''),
-          );
-          attr.add(
-            // TODO: remove ignore when our minimum core version >= 1.0
-            // ignore: avoid_dynamic_calls
-            'mainAxisAlignment=${dynamicWidget.mainAxisAlignment}'
-                .replaceAll('MainAxisAlignment.', ''),
-          );
-
+      // Keep compatibility with core versions that do not expose this type.
+      if (widget.runtimeType.toString() == 'HtmlFlex') {
+        attr.add(
           // TODO: remove ignore when our minimum core version >= 1.0
           // ignore: avoid_dynamic_calls
-          final spacing = dynamicWidget.spacing as double;
-          if (spacing != 0.0) {
-            attr.add('spacing=$spacing');
-          }
+          'crossAxisAlignment=${dynamicWidget.crossAxisAlignment}'
+              .replaceAll('CrossAxisAlignment.', ''),
+        );
+        attr.add(
+          // TODO: remove ignore when our minimum core version >= 1.0
+          // ignore: avoid_dynamic_calls
+          'direction=${dynamicWidget.direction}'.replaceAll('Axis.', ''),
+        );
+        attr.add(
+          // TODO: remove ignore when our minimum core version >= 1.0
+          // ignore: avoid_dynamic_calls
+          'mainAxisAlignment=${dynamicWidget.mainAxisAlignment}'
+              .replaceAll('MainAxisAlignment.', ''),
+        );
+
+        // TODO: remove ignore when our minimum core version >= 1.0
+        // ignore: avoid_dynamic_calls
+        final spacing = dynamicWidget.spacing as double;
+        if (spacing != 0.0) {
+          attr.add('spacing=$spacing');
+        }
       }
     }
 
@@ -822,18 +822,18 @@ class Explainer {
 
     if (widget is SingleChildRenderObjectWidget) {
       final dynamicWidget = widget as dynamic;
-      switch (widget.runtimeType.toString()) {
-        case 'HorizontalMargin':
-          // TODO: remove ignore when our minimum core version >= 1.0
-          // ignore: avoid_dynamic_calls
-          final left = dynamicWidget.left as double;
-          // TODO: remove ignore when our minimum core version >= 1.0
-          // ignore: avoid_dynamic_calls
-          final right = dynamicWidget.right as double;
-          attr.add(
-            'left=${left.isInfinite ? '∞' : left.truncate()},'
-            'right=${right.isInfinite ? '∞' : right.truncate()}',
-          );
+      // Keep compatibility with core versions that do not expose this type.
+      if (widget.runtimeType.toString() == 'HorizontalMargin') {
+        // TODO: remove ignore when our minimum core version >= 1.0
+        // ignore: avoid_dynamic_calls
+        final left = dynamicWidget.left as double;
+        // TODO: remove ignore when our minimum core version >= 1.0
+        // ignore: avoid_dynamic_calls
+        final right = dynamicWidget.right as double;
+        attr.add(
+          'left=${left.isInfinite ? '∞' : left.truncate()},'
+          'right=${right.isInfinite ? '∞' : right.truncate()}',
+        );
       }
     }
 

--- a/packages/core/test/core_config_test.dart
+++ b/packages/core/test/core_config_test.dart
@@ -384,7 +384,7 @@ void main() {
         (_, __) {},
       );
 
-      return helper.explainWithoutPumping(useExplainer: false);
+      return await helper.explainWithoutPumping(useExplainer: false);
     }
 
     testWidgets('[sync] renders default', (tester) async {
@@ -522,7 +522,7 @@ void main() {
         _OnTapUrlApp(
           href: href,
           onTapCallbackResults: onTapCallbackResults,
-          onTapUrl: (_) => false,
+          onTapUrl: (_) => Future.value(false),
         ),
       );
       await tester.pumpAndSettle();
@@ -539,7 +539,7 @@ void main() {
         _OnTapUrlApp(
           href: href,
           onTapCallbackResults: onTapCallbackResults,
-          onTapUrl: (_) => true,
+          onTapUrl: (_) => Future.value(true),
         ),
       );
       await tester.pumpAndSettle();

--- a/packages/enhanced/test/config_test.dart
+++ b/packages/enhanced/test/config_test.dart
@@ -382,7 +382,7 @@ void main() {
         (_, __) {},
       );
 
-      return helper.explainWithoutPumping(useExplainer: false);
+      return await helper.explainWithoutPumping(useExplainer: false);
     }
 
     testWidgets('[sync] renders default', (tester) async {

--- a/packages/fwfh_cached_network_image/test/_.dart
+++ b/packages/fwfh_cached_network_image/test/_.dart
@@ -42,7 +42,7 @@ Future<String> explain(
   await tester.runAsync(() => Future.delayed(const Duration(milliseconds: 10)));
   await tester.pump();
 
-  return helper.explainWithoutPumping(
+  return await helper.explainWithoutPumping(
     explainer: cachedNetworkImageExplainer,
     useExplainer: useExplainer,
   );

--- a/packages/fwfh_chewie/test/_.dart
+++ b/packages/fwfh_chewie/test/_.dart
@@ -50,7 +50,7 @@ Future<String> explain(
   await tester.runAsync(() => Future.delayed(delay));
   await tester.pump();
 
-  return helper.explainWithoutPumping(
+  return await helper.explainWithoutPumping(
     explainer: videoPlayerExplainer,
     useExplainer: useExplainer,
   );


### PR DESCRIPTION
Fix async future returns and type-name switches for lint 2.14.0. Preserve SDK floors and backward-compatible test helpers; correct existing async callback tests to return futures.

Validated all nine roots on Flutter 3.47.2 and passed 1,501 tests plus no-mistakes. Goldens were skipped on macOS; Linux CI remains pending.
