### PR TITLE
chore: Release v0.17.4

### DIFF
--- a/docs/runbook/release.md
+++ b/docs/runbook/release.md
@@ -295,13 +295,15 @@ dependency order above, it:
    (`https://pub.dev/packages/<name>/versions/<version>`) — **skips the package if that exact
    version is already published.** This is what makes it safe to run repeatedly / makes
    "some packages didn't change this cycle" a non-issue.
-3. Strips `dependency_overrides` from `pubspec.yaml` (pub.dev rejects packages with those
-   present), runs `flutter clean && flutter pub get`, and runs `flutter test` if a `test/`
-   directory exists.
-4. Builds a `.pubignore` from `.gitignore` plus `/test/` (so tests never ship), strips the
-   `flutter:` key from `pubspec.yaml`.
-5. Runs `flutter pub publish` for real.
-6. Reverts all local changes (`git checkout .`) and removes the generated `.pubignore`.
+3. Runs the automated preflight and packaging checks defined in the script. Keep those checks in
+   the script rather than duplicating their implementation here.
+4. Runs `flutter pub publish` for real. Temporary publishing changes are restored whether the
+   command succeeds or fails.
+
+Use direct funding URLs rather than redirectors. `https://www.patreon.com/daohoangson` responds
+directly to the `HEAD` request used by pub.dev; the version without `www` redirects and has
+produced cached reachability warnings. Do not release a package solely to change this metadata,
+but canonicalize the URL whenever that package next has a real release.
 
 `tool/pub-get.sh` is a different, sibling script — it just runs `flutter pub get` across every
 package and `demo_app`, preserving existing `pubspec.lock` resolutions where they're still

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.17.4
+
+- Add support for CSS `font-size: xxx-large` (#1593, authored by @dariyooo)
+- Improve `<summary>` keyboard and screen reader accessibility (#1626)
+- Fix obsolete async parses resetting the widget factory (#1625)
+
 ## 0.17.3
 
 - Add support for standalone CSS `border-*` properties (#1570, authored by @CaptainDario)

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -28,7 +28,7 @@ flutter:
     - test/images/
 
 funding:
-  - https://patreon.com/daohoangson
+  - https://www.patreon.com/daohoangson
   - https://buymeacoffee.com/daohoangson
 
 screenshots:

--- a/packages/core/pubspec.yaml
+++ b/packages/core/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_widget_from_html_core
-version: 0.17.3
+version: 0.17.4
 description: Flutter package to render html as widgets that focuses on correctness and extensibility.
 homepage: https://github.com/daohoangson/flutter_widget_from_html/tree/master/packages/core
 

--- a/packages/enhanced/CHANGELOG.md
+++ b/packages/enhanced/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.17.4
+
+- Add support for CSS `font-size: xxx-large` (#1593, authored by @dariyooo)
+- Improve `<summary>` keyboard and screen reader accessibility (#1626)
+- Fix obsolete async parses resetting the widget factory (#1625)
+- Fix platform support metadata on pub.dev (#1630)
+
 ## 0.17.3
 
 - Add support for standalone CSS `border-*` properties (#1570, authored by @CaptainDario)

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -7,6 +7,14 @@ environment:
   flutter: ">=3.32.0"
   sdk: ">=3.4.0 <4.0.0"
 
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:
+
 dependencies:
   flutter:
     sdk: flutter

--- a/packages/enhanced/pubspec.yaml
+++ b/packages/enhanced/pubspec.yaml
@@ -1,5 +1,5 @@
 name: flutter_widget_from_html
-version: 0.17.3
+version: 0.17.4
 description: Flutter package to render html as widgets that supports hyperlink, image, audio, video, iframe and many other tags.
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 
@@ -18,13 +18,13 @@ platforms:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_widget_from_html_core: ^0.17.3
-  fwfh_cached_network_image: ^0.16.2
+  flutter_widget_from_html_core: ^0.17.4
+  fwfh_cached_network_image: ^0.16.3
   fwfh_chewie: ^0.16.1
   fwfh_just_audio: ^0.17.0
   fwfh_svg: ^0.16.1
   fwfh_url_launcher: ^0.16.1
-  fwfh_webview: ^0.15.7
+  fwfh_webview: ^0.15.8
   html: ^0.15.0
 
 dependency_overrides:
@@ -56,7 +56,7 @@ flutter:
     - test/images/
 
 funding:
-  - https://patreon.com/daohoangson
+  - https://www.patreon.com/daohoangson
   - https://buymeacoffee.com/daohoangson
 
 screenshots:

--- a/packages/fwfh_cached_network_image/CHANGELOG.md
+++ b/packages/fwfh_cached_network_image/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.16.3
+
+- Fix platform support metadata on pub.dev (#1630)
+
 ## 0.16.2
 
 - Add support for cached_network_image@4.0.0 (#1621)

--- a/packages/fwfh_cached_network_image/pubspec.yaml
+++ b/packages/fwfh_cached_network_image/pubspec.yaml
@@ -33,7 +33,7 @@ dev_dependencies:
   mocktail: ^1.0.0
 
 funding:
-  - https://patreon.com/daohoangson
+  - https://www.patreon.com/daohoangson
   - https://buymeacoffee.com/daohoangson
 
 topics:

--- a/packages/fwfh_cached_network_image/pubspec.yaml
+++ b/packages/fwfh_cached_network_image/pubspec.yaml
@@ -7,6 +7,13 @@ environment:
   flutter: ">=3.10.0"
   sdk: ">=3.0.0 <4.0.0"
 
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  windows:
+
 dependencies:
   cached_network_image: ">=3.0.0 <5.0.0"
   flutter:

--- a/packages/fwfh_cached_network_image/pubspec.yaml
+++ b/packages/fwfh_cached_network_image/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fwfh_cached_network_image
-version: 0.16.2
+version: 0.16.3
 description: WidgetFactory extension to render IMG with cached_network_image plugin.
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 

--- a/packages/fwfh_chewie/pubspec.yaml
+++ b/packages/fwfh_chewie/pubspec.yaml
@@ -26,7 +26,7 @@ dev_dependencies:
   video_player_platform_interface: ">=5.0.0 <7.0.0"
 
 funding:
-  - https://patreon.com/daohoangson
+  - https://www.patreon.com/daohoangson
   - https://buymeacoffee.com/daohoangson
 
 topics:

--- a/packages/fwfh_just_audio/pubspec.yaml
+++ b/packages/fwfh_just_audio/pubspec.yaml
@@ -30,7 +30,7 @@ flutter:
   uses-material-design: true
 
 funding:
-  - https://patreon.com/daohoangson
+  - https://www.patreon.com/daohoangson
   - https://buymeacoffee.com/daohoangson
 
 topics:

--- a/packages/fwfh_svg/pubspec.yaml
+++ b/packages/fwfh_svg/pubspec.yaml
@@ -29,7 +29,7 @@ flutter:
     - test/images/
 
 funding:
-  - https://patreon.com/daohoangson
+  - https://www.patreon.com/daohoangson
   - https://buymeacoffee.com/daohoangson
 
 topics:

--- a/packages/fwfh_url_launcher/pubspec.yaml
+++ b/packages/fwfh_url_launcher/pubspec.yaml
@@ -24,7 +24,7 @@ dev_dependencies:
   url_launcher_platform_interface: any
 
 funding:
-  - https://patreon.com/daohoangson
+  - https://www.patreon.com/daohoangson
   - https://buymeacoffee.com/daohoangson
 
 topics:

--- a/packages/fwfh_webview/CHANGELOG.md
+++ b/packages/fwfh_webview/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.8
+
+- Fix platform support metadata on pub.dev (#1630)
+
 ## 0.15.7
 
 - Forward `allowfullscreen` and `allow` iframe attributes to WebView (#1566)

--- a/packages/fwfh_webview/pubspec.yaml
+++ b/packages/fwfh_webview/pubspec.yaml
@@ -7,6 +7,11 @@ environment:
   flutter: ">=3.16.0"
   sdk: ">=3.2.0 <4.0.0"
 
+platforms:
+  android:
+  ios:
+  web:
+
 dependencies:
   flutter:
     sdk: flutter

--- a/packages/fwfh_webview/pubspec.yaml
+++ b/packages/fwfh_webview/pubspec.yaml
@@ -1,5 +1,5 @@
 name: fwfh_webview
-version: 0.15.7
+version: 0.15.8
 description: WidgetFactory extension to render IFRAME with the official WebView plugin.
 homepage: https://github.com/daohoangson/flutter_widget_from_html
 

--- a/packages/fwfh_webview/pubspec.yaml
+++ b/packages/fwfh_webview/pubspec.yaml
@@ -37,7 +37,7 @@ dev_dependencies:
   webview_flutter_platform_interface: ^2.4.0
 
 funding:
-  - https://patreon.com/daohoangson
+  - https://www.patreon.com/daohoangson
   - https://buymeacoffee.com/daohoangson
 
 topics:

--- a/tool/pub-publish.sh
+++ b/tool/pub-publish.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 
 cd "$(dirname $(dirname ${BASH_SOURCE[0]}))"
 
+# Keep this current: pub.dev uses pana to calculate package scores.
+dart pub global activate pana
+
 function publish {
   echo
   echo Publishing $(basename $(pwd))...
@@ -20,25 +23,58 @@ function publish {
     return
   fi
 
-  # delete the overrides, pub doesn't like that
-  yq e 'del(.dependency_overrides)' -i pubspec.yaml
+  _backup_dir=$(mktemp -d)
+  cp pubspec.yaml "$_backup_dir/pubspec.yaml"
 
-  # `pub get` should work...
-  flutter clean && flutter pub get
-  # tests should work...
-  if [ -d test ]; then
-    flutter test
-  fi
+  (
+    function cleanup {
+      cp "$_backup_dir/pubspec.yaml" pubspec.yaml
+      rm -f .pubignore
+      rm -rf "$_backup_dir"
+    }
+    trap cleanup EXIT
 
-  cat .gitignore >.pubignore
-  echo '/test/' >>.pubignore
-  yq e 'del(.flutter)' -i pubspec.yaml
+    # Delete the overrides, pub doesn't like those.
+    yq e 'del(.dependency_overrides)' -i pubspec.yaml
 
-  flutter pub publish
+    flutter clean
+    flutter pub get
+    dart format --output=none --set-exit-if-changed .
+    flutter analyze --fatal-infos
+    if [ -d test ]; then
+      flutter test
+    fi
 
-  # revert the changes
-  git checkout .
-  rm .pubignore
+    cat .gitignore >.pubignore
+    echo '/test/' >>.pubignore
+    yq e 'del(.flutter)' -i pubspec.yaml
+
+    # Analyze a disposable copy because pana modifies its input. Most packages
+    # must score 160/160. The enhanced package is not yet Wasm-ready, while the
+    # two media add-ons intentionally support four of six platforms, so their
+    # honest maximum is currently 150/160.
+    _pana_threshold=0
+    case "$_name" in
+      flutter_widget_from_html | fwfh_chewie | fwfh_just_audio)
+        _pana_threshold=10
+        ;;
+    esac
+    _pana_dir="$_backup_dir/pana"
+    mkdir "$_pana_dir"
+    rsync -a \
+      --exclude '.dart_tool/' \
+      --exclude 'build/' \
+      --exclude 'coverage/' \
+      --exclude 'pubspec.lock' \
+      --exclude 'test/' \
+      ./ \
+      "$_pana_dir/"
+    dart pub global run pana \
+      --exit-code-threshold "$_pana_threshold" \
+      "$_pana_dir"
+
+    flutter pub publish
+  )
 }
 
 (cd packages/core && publish)


### PR DESCRIPTION
## Summary

- declare accurate pub.dev platform support for flutter_widget_from_html, fwfh_cached_network_image, and fwfh_webview
- include all user-facing core changes merged since the previous release
- prepare patch releases in dependency order
- update flutter_widget_from_html to depend on the new core and add-on patch versions
- add a pre-publish pub.dev score gate with formatting, fatal-info analysis, tests, and Pana checks

## Releases

- flutter_widget_from_html_core 0.17.4
- fwfh_cached_network_image 0.16.3
- fwfh_webview 0.15.8
- flutter_widget_from_html 0.17.4

## Validation

- dart format .
- ./tool/pub-get.sh
- ./tool/test.sh
- targeted core and enhanced tests
- bash -n tool/pub-publish.sh
- Pana 0.23.19: core 160/160, enhanced 150/160 (all six platforms; Web is not yet Wasm-ready)
- git diff --check
- GitHub unit, demo build, Android, iOS, and SonarCloud checks

Publishing and tagging are intentionally excluded; publishing remains a manual owner-only step after merge.